### PR TITLE
replace check with conference existing by id to using case name, numb…

### DIFF
--- a/VideoAPI/Video.API/Controllers/ConferenceController.cs
+++ b/VideoAPI/Video.API/Controllers/ConferenceController.cs
@@ -254,10 +254,10 @@ namespace Video.API.Controllers
 
         private async Task<Guid> CreateConference(BookNewConferenceRequest request)
         {
-            var existingConference = await _queryHandler.Handle<GetConferenceByHearingRefIdQuery, Conference>(
-                new GetConferenceByHearingRefIdQuery(request.HearingRefId));
+            var existingConference = await _queryHandler.Handle<CheckConferenceOpenQuery, Conference>(
+                new CheckConferenceOpenQuery(request.ScheduledDateTime, request.CaseNumber, request.CaseName));
 
-            if (existingConference != null && !existingConference.IsClosed()) return existingConference.Id;
+            if (existingConference != null) return existingConference.Id;
             
             var participants = request.Participants.Select(x =>
                     new Participant(x.ParticipantRefId, x.Name, x.DisplayName, x.Username, x.UserRole,

--- a/VideoAPI/VideoApi.DAL/Queries/CheckConferenceOpenQuery.cs
+++ b/VideoAPI/VideoApi.DAL/Queries/CheckConferenceOpenQuery.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using VideoApi.DAL.Queries.Core;
+using VideoApi.Domain;
+using VideoApi.Domain.Enums;
+
+namespace VideoApi.DAL.Queries
+{
+    public class CheckConferenceOpenQuery : IQuery
+    {
+        public CheckConferenceOpenQuery(DateTime scheduledDateTime, string caseNumber, string caseName)
+        {
+            ScheduledDateTime = scheduledDateTime;
+            CaseNumber = caseNumber;
+            CaseName = caseName;
+        }
+
+        public DateTime ScheduledDateTime { get; set; }
+        public string CaseNumber { get; set; }
+        public string CaseName { get; set; }
+    }
+
+    public class CheckConferenceOpenQueryHandler : IQueryHandler<CheckConferenceOpenQuery, Conference>
+    {
+        private readonly VideoApiDbContext _context;
+
+        public CheckConferenceOpenQueryHandler(VideoApiDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Conference> Handle(CheckConferenceOpenQuery query)
+        {
+            return await _context.Conferences.SingleOrDefaultAsync(x =>
+                x.ScheduledDateTime == query.ScheduledDateTime
+                && x.CaseName == query.CaseName
+                && x.CaseNumber == query.CaseNumber
+                && x.State != ConferenceState.Closed).ConfigureAwait(false);
+        }
+    }
+}

--- a/VideoAPI/VideoApi.IntegrationTests/Database/Queries/CheckConferenceOpenQueryTests.cs
+++ b/VideoAPI/VideoApi.IntegrationTests/Database/Queries/CheckConferenceOpenQueryTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using VideoApi.DAL;
+using VideoApi.DAL.Queries;
+
+namespace VideoApi.IntegrationTests.Database.Queries
+{
+    public class CheckConferenceOpenQueryTests : DatabaseTestsBase
+    {
+        private CheckConferenceOpenQueryHandler _handler;
+        private Guid _newConferenceId;
+        
+        [SetUp]
+        public void Setup()
+        {
+            var context = new VideoApiDbContext(VideoBookingsDbContextOptions);
+            _handler = new CheckConferenceOpenQueryHandler(context);
+            _newConferenceId = Guid.Empty;
+        }
+
+        [Test]
+        public async Task should_return_null_when_conference_not_already_booked()
+        {
+            var query = new CheckConferenceOpenQuery(DateTime.UtcNow, "12345678HBGH", "New Case");
+
+            var conference = await _handler.Handle(query);
+
+            conference.Should().BeNull();
+        }
+        
+        [Test]
+        public async Task should_return_conference_when_query_is_matched()
+        {
+            var seededConference = await TestDataManager.SeedConference();
+
+            var query = new CheckConferenceOpenQuery(seededConference.ScheduledDateTime, seededConference.CaseNumber,
+                seededConference.CaseName);
+
+            var conference = await _handler.Handle(query);
+
+            conference.Should().NotBeNull();
+            conference.Id.Should().Be(seededConference.Id);
+        }
+        
+        [TearDown]
+        public async Task TearDown()
+        {
+            if (_newConferenceId != Guid.Empty)
+            {
+                TestContext.WriteLine($"Removing test conference {_newConferenceId}");
+                await TestDataManager.RemoveConference(_newConferenceId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

associated to [VIH-4722](https://tools.hmcts.net/jira/browse/VIH-4722)



### Change description ###

This is hardening the check in the video api to ensure a conference is not already booked for a hearing already scheduled with the same case type, name and time since the hearing id is generated on the fly on each request and cannot be guaranteed to be a safe means to check when bookings are entered twice.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
