### PR TITLE
Participant id is null when suspend event is raised for technical ass…

### DIFF
--- a/VideoAPI/Video.API/Validations/ConferenceEventRequestValidation.cs
+++ b/VideoAPI/Video.API/Validations/ConferenceEventRequestValidation.cs
@@ -23,7 +23,7 @@ namespace Video.API.Validations
                 .WithMessage(InvalidConferenceIdFormatErrorMessage);
             
             RuleFor(x => x.EventId).NotEmpty().WithMessage(NoEventIdErrorMessage);
-            RuleFor(x => x.ParticipantId).NotEmpty().WithMessage(NoParticipantIdErrorMessage);
+            RuleFor(x => x.ParticipantId).NotEmpty().When(x => x.EventType != EventType.Suspend).WithMessage(NoParticipantIdErrorMessage);
             RuleFor(x => x.ParticipantId).Must(x => Guid.TryParse(x, out _))
                 .WithMessage(InvalidParticipantIdFormatErrorMessage);
             

--- a/VideoAPI/Video.API/Validations/ConferenceEventRequestValidation.cs
+++ b/VideoAPI/Video.API/Validations/ConferenceEventRequestValidation.cs
@@ -24,7 +24,7 @@ namespace Video.API.Validations
             
             RuleFor(x => x.EventId).NotEmpty().WithMessage(NoEventIdErrorMessage);
             RuleFor(x => x.ParticipantId).NotEmpty().When(x => x.EventType != EventType.Suspend).WithMessage(NoParticipantIdErrorMessage);
-            RuleFor(x => x.ParticipantId).Must(x => Guid.TryParse(x, out _))
+            RuleFor(x => x.ParticipantId).Must(x => Guid.TryParse(x, out _)).When(x => x.EventType != EventType.Suspend)
                 .WithMessage(InvalidParticipantIdFormatErrorMessage);
             
             RuleFor(x => x.EventType)

--- a/VideoAPI/VideoApi.Domain/Conference.cs
+++ b/VideoAPI/VideoApi.Domain/Conference.cs
@@ -132,5 +132,15 @@ namespace VideoApi.Domain
             ScheduledDateTime = scheduledDateTime;
             ScheduledDuration = scheduledDuration;
         }
+
+        public Participant GetJudge()
+        {
+            return Participants.SingleOrDefault(x => x.IsJudge());
+        }
+
+        public Participant GetVideoHearingOfficer()
+        {
+            return Participants.SingleOrDefault(x => x.IsVideoHearingOfficer());
+        }
     }
 }

--- a/VideoAPI/VideoApi.Domain/Participant.cs
+++ b/VideoAPI/VideoApi.Domain/Participant.cs
@@ -61,5 +61,14 @@ namespace VideoApi.Domain
         {
             return TestCallResult;
         }
+
+        public bool IsJudge()
+        {
+            return UserRole == UserRole.Judge;
+        }
+        public bool IsVideoHearingOfficer()
+        {
+            return UserRole == UserRole.VideoHearingsOfficer;
+        }
     }
 }

--- a/VideoAPI/VideoApi.Events/Handlers/DisconnectedEventHandler.cs
+++ b/VideoAPI/VideoApi.Events/Handlers/DisconnectedEventHandler.cs
@@ -24,7 +24,7 @@ namespace VideoApi.Events.Handlers
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
             await PublishParticipantDisconnectMessage();
-            if (SourceParticipant.UserRole == UserRole.Judge) await PublishSuspendedEventMessage();
+            if (SourceParticipant.IsJudge()) await PublishSuspendedEventMessage();
         }
 
         private async Task PublishParticipantDisconnectMessage()
@@ -39,9 +39,8 @@ namespace VideoApi.Events.Handlers
 
         private async Task AddDisconnectedTask()
         {
-            var taskType = SourceParticipant.UserRole == UserRole.Judge ? TaskType.Judge : TaskType.Participant;
-            var disconnected =
-                new AddTaskCommand(SourceConference.Id, SourceParticipant.Id, "Disconnected", taskType);
+            var taskType = SourceParticipant.IsJudge() ? TaskType.Judge : TaskType.Participant;
+            var disconnected = new AddTaskCommand(SourceConference.Id, SourceParticipant.Id, "Disconnected", taskType);
             await CommandHandler.Handle(disconnected);
         }
 

--- a/VideoAPI/VideoApi.Events/Handlers/JoinedEventHandler.cs
+++ b/VideoAPI/VideoApi.Events/Handlers/JoinedEventHandler.cs
@@ -23,11 +23,10 @@ namespace VideoApi.Events.Handlers
 
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
-            var isJudge = SourceParticipant.UserRole == UserRole.Judge;
-            var participantState = isJudge ? ParticipantState.InHearing : ParticipantState.Available;
+            var participantState = SourceParticipant.IsJudge() ? ParticipantState.InHearing : ParticipantState.Available;
 
             await PublishParticipantStatusMessage(participantState);
-            if (isJudge) await PublishLiveEventMessage();
+            if (SourceParticipant.IsJudge()) await PublishLiveEventMessage();
 
             var command = new UpdateParticipantStatusCommand(SourceConference.Id, SourceParticipant.Id, participantState);
             await CommandHandler.Handle(command);

--- a/VideoAPI/VideoApi.Events/Handlers/SuspendEventHandler.cs
+++ b/VideoAPI/VideoApi.Events/Handlers/SuspendEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using VideoApi.DAL.Commands;
@@ -29,7 +30,14 @@ namespace VideoApi.Events.Handlers
             var command = new UpdateConferenceStatusCommand(SourceConference.Id, conferenceState);
             await CommandHandler.Handle(command);
 
-            var taskCommand = new AddTaskCommand(SourceConference.Id, SourceParticipant.Id, "Hearing suspended", TaskType.Hearing);
+            var reason = "Hearing suspended";
+            if (SourceParticipant == null)
+            {
+                SourceParticipant = SourceConference.GetJudge();
+                reason = "Technical assistance";
+            }
+
+            var taskCommand = new AddTaskCommand(SourceConference.Id, SourceParticipant.Id, reason, TaskType.Hearing);
             await CommandHandler.Handle(taskCommand);
         }
     }

--- a/VideoAPI/VideoApi.UnitTests/Events/SuspendEventHandlerTests.cs
+++ b/VideoAPI/VideoApi.UnitTests/Events/SuspendEventHandlerTests.cs
@@ -47,5 +47,38 @@ namespace VideoApi.UnitTests.Events
                     command.ConferenceId == conference.Id &&
                     command.Body == "Hearing suspended")), Times.Once);
         }
+
+        [Test]
+        public async Task should_send_messages_to_participants_on_suspended_for_technical_assistance()
+        {
+            _eventHandler = new SuspendEventHandler(QueryHandlerMock.Object, CommandHandlerMock.Object,
+                ServiceBusQueueClient, EventHubContextMock.Object);
+
+            var conference = TestConference;
+            var participantCount = conference.GetParticipants().Count + 1; // plus one for admin
+            var callbackEvent = new CallbackEvent
+            {
+                EventType = EventType.Pause,
+                EventId = Guid.NewGuid().ToString(),
+                ConferenceId = conference.Id,
+                TimeStampUtc = DateTime.UtcNow,
+            };
+
+            await _eventHandler.HandleAsync(callbackEvent);
+
+            // Verify messages sent to event hub clients
+            EventHubClientMock.Verify(x => x.ConferenceStatusMessage(conference.Id, ConferenceState.Suspended),
+                Times.Exactly(participantCount));
+
+            CommandHandlerMock.Verify(
+                x => x.Handle(It.Is<UpdateConferenceStatusCommand>(command =>
+                    command.ConferenceId == conference.Id &&
+                    command.ConferenceState == ConferenceState.Suspended)), Times.Once);
+
+            CommandHandlerMock.Verify(
+                x => x.Handle(It.Is<AddTaskCommand>(command =>
+                    command.ConferenceId == conference.Id &&
+                    command.Body == "Technical assistance")), Times.Once);
+        }
     }
 }

--- a/VideoAPI/VideoApi.UnitTests/Validation/ConferenceEventRequestValidationTests.cs
+++ b/VideoAPI/VideoApi.UnitTests/Validation/ConferenceEventRequestValidationTests.cs
@@ -125,6 +125,29 @@ namespace VideoApi.UnitTests.Validation
                 .Should().BeTrue();
         }
 
+        [Test]
+        public async Task should_return_valid_for_suspend_event_without_participantid()
+        {
+            var request = BuildRequest();
+            request.EventType = EventType.Suspend;
+            request.ParticipantId = string.Empty;
+
+            var result = await _validator.ValidateAsync(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task should_return_invalid_for_transfer_event_without_participantid()
+        {
+            var request = BuildRequest();
+            request.EventType = EventType.Transfer;
+            request.ParticipantId = string.Empty;
+            var result = await _validator.ValidateAsync(request);
+
+            result.IsValid.Should().BeFalse();
+        }
+
         private ConferenceEventRequest BuildRequest()
         {
             var request = Builder<ConferenceEventRequest>.CreateNew()


### PR DESCRIPTION
…**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
