### PR TITLE
Include the hearing id in the summary response

### DIFF
--- a/VideoAPI/Testing.Common/Assertions/AssertConferenceSummaryResponse.cs
+++ b/VideoAPI/Testing.Common/Assertions/AssertConferenceSummaryResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using VideoApi.Contract.Responses;
-using VideoApi.Domain.Enums;
 
 namespace Testing.Common.Assertions
 {
@@ -16,6 +15,7 @@ namespace Testing.Common.Assertions
             conference.ScheduledDuration.Should().BeGreaterThan(0);
             conference.ScheduledDateTime.Should().NotBe(DateTime.MinValue);
             conference.Id.Should().NotBeEmpty();
+            conference.HearingId.Should().NotBeEmpty();
         }
     }
 }

--- a/VideoAPI/Video.API/Mappings/ConferenceToSummaryResponseMapper.cs
+++ b/VideoAPI/Video.API/Mappings/ConferenceToSummaryResponseMapper.cs
@@ -16,6 +16,7 @@ namespace Video.API.Mappings
             return new ConferenceSummaryResponse
             {
                 Id = conference.Id,
+                HearingId = conference.HearingRefId,
                 CaseType = conference.CaseType,
                 CaseNumber = conference.CaseNumber,
                 CaseName = conference.CaseName,

--- a/VideoAPI/VideoApi.Contract/Responses/ConferenceSummaryResponse.cs
+++ b/VideoAPI/VideoApi.Contract/Responses/ConferenceSummaryResponse.cs
@@ -7,6 +7,7 @@ namespace VideoApi.Contract.Responses
     public class ConferenceSummaryResponse
     {
         public Guid Id { get; set; }
+        public Guid HearingId { get; set; }
         public DateTime ScheduledDateTime { get; set; }
         public DateTime? ClosedDateTime { get; set; }
         public string CaseType { get; set; }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-5049](https://tools.hmcts.net/jira/browse/VIH-5049)

### Change description ###

The hearing id is now included in the conference summary response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
