### PR TITLE
VIH-5737 Remove get conference db call when closing conference

### DIFF
--- a/VideoAPI/VideoApi.UnitTests/Controllers/Conference/CloseConferenceTests.cs
+++ b/VideoAPI/VideoApi.UnitTests/Controllers/Conference/CloseConferenceTests.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Net;
-using FluentAssertions;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
-using Testing.Common.Assertions;
 using VideoApi.DAL.Commands;
-using VideoApi.DAL.Queries;
 using VideoApi.Domain;
 using Task = System.Threading.Tasks.Task;
 
@@ -21,7 +16,6 @@ namespace VideoApi.UnitTests.Controllers.Conference
 
             await Controller.CloseConferenceAsync(Guid.NewGuid());
 
-            QueryHandlerMock.Verify(q => q.Handle<GetConferenceByIdQuery, VideoApi.Domain.Conference>(It.IsAny<GetConferenceByIdQuery>()), Times.Once);
             CommandHandlerMock.Verify(c => c.Handle(It.IsAny<CloseConferenceCommand>()), Times.Once);
             VideoPlatformServiceMock.Verify(v => v.DeleteVirtualCourtRoomAsync(It.IsAny<Guid>()), Times.Never);
         }
@@ -29,39 +23,12 @@ namespace VideoApi.UnitTests.Controllers.Conference
         [Test]
         public async Task Should_close_conference_and_remove_court_room_for_given_valid_conference_id()
         {
-            VideoPlatformServiceMock.Setup(v => v.GetVirtualCourtRoomAsync(It.IsAny<Guid>())).ReturnsAsync(MeetingRoom);
-
+            var meetingRoom = new MeetingRoom("admin", "judge", "participant", "node");
+            VideoPlatformServiceMock.Setup(v => v.GetVirtualCourtRoomAsync(It.IsAny<Guid>())).ReturnsAsync(meetingRoom);
             await Controller.CloseConferenceAsync(Guid.NewGuid());
 
-            QueryHandlerMock.Verify(q => q.Handle<GetConferenceByIdQuery, VideoApi.Domain.Conference>(It.IsAny<GetConferenceByIdQuery>()), Times.Once);
             CommandHandlerMock.Verify(c => c.Handle(It.IsAny<CloseConferenceCommand>()), Times.Once);
             VideoPlatformServiceMock.Verify(v => v.DeleteVirtualCourtRoomAsync(It.IsAny<Guid>()), Times.Once);
         }
-
-        [Test]
-        public async Task Should_return_notfound_with_no_matching_conference()
-        {
-            QueryHandlerMock
-             .Setup(x => x.Handle<GetConferenceByIdQuery, VideoApi.Domain.Conference>(It.IsAny<GetConferenceByIdQuery>()))
-             .ReturnsAsync((VideoApi.Domain.Conference)null);
-
-            var result = await Controller.CloseConferenceAsync(Guid.NewGuid());
-
-            var typedResult = (NotFoundResult)result;
-            typedResult.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
-        }
-
-        [Test]
-        public async Task Should_return_bad_request_for_given_invalid_conferenceid()
-        {
-            var conferenceId = Guid.Empty;
-
-            var result = await Controller.CloseConferenceAsync(conferenceId);
-
-            var typedResult = (ObjectResult)result;
-            typedResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
-            ((SerializableError)typedResult.Value).ContainsKeyAndErrorMessage(nameof(conferenceId), $"Please provide a valid {nameof(conferenceId)}");
-        }
-
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-5737

### Change description ###

Remove call  to get  conference query when close conference command already checks for conference

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
