### PR TITLE
VIH-5842 Modify_get_conferences_to_only_return_the_latest_10_hearings_on_the_VHO_view

### DIFF
--- a/VideoAPI/VideoApi.DAL/Queries/GetConferencesTodayForAdminQuery.cs
+++ b/VideoAPI/VideoApi.DAL/Queries/GetConferencesTodayForAdminQuery.cs
@@ -31,6 +31,7 @@ namespace VideoApi.DAL.Queries
                 .AsNoTracking()
                 .Where(x => x.ScheduledDateTime >= today && x.ScheduledDateTime < tomorrow)
                 .OrderBy(x => x.ScheduledDateTime)
+                .Take(10)
                 .ToListAsync();
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-5842
### Change description ###
 - retrieve 10 hearings only.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
