### PR TITLE
VIH-5953 Drop index if already exists

### DIFF
--- a/VideoAPI/VideoApi.DAL/Migrations/20200430155005_CreateConferenceTableIndexScheduledDate.cs
+++ b/VideoAPI/VideoApi.DAL/Migrations/20200430155005_CreateConferenceTableIndexScheduledDate.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace VideoApi.DAL.Migrations
 {
@@ -6,6 +6,7 @@ namespace VideoApi.DAL.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql(@"DROP INDEX IF EXISTS [IX_Conference_ScheduledDateTime] ON [dbo].[Conference]");
             migrationBuilder.CreateIndex(
                 name: "IX_Conference_ScheduledDateTime",
                 table: "Conference",


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Drops the index if already exists. This was a hotfixed as V1.11.2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
