### PR TITLE
VIH-7167 improve event handler reliability

### DIFF
--- a/VideoApi/VideoApi.Domain/Room.cs
+++ b/VideoApi/VideoApi.Domain/Room.cs
@@ -52,48 +52,40 @@ namespace VideoApi.Domain
 
         public void AddParticipant(RoomParticipant participant)
         {
-            if (DoesParticipantExist(participant))
+            if (!DoesParticipantExist(participant))
             {
-                throw new DomainRuleException(nameof(participant), "Participant already exists in room");
+                RoomParticipants.Add(participant);
             }
-
-            RoomParticipants.Add(participant);
         }
 
         public void RemoveParticipant(RoomParticipant participant)
         {
-            if (!DoesParticipantExist(participant))
+            if (DoesParticipantExist(participant))
             {
-                throw new DomainRuleException(nameof(participant), "Participant does not exist in room");
+                var existingParticipant = RoomParticipants.Single(x => x.ParticipantId == participant.ParticipantId);
+
+                RoomParticipants.Remove(existingParticipant);
+                UpdateStatus();
             }
-
-            var existingParticipant = RoomParticipants.Single(x => x.ParticipantId == participant.ParticipantId);
-
-            RoomParticipants.Remove(existingParticipant);
-            UpdateStatus();
         }
 
         public void AddEndpoint(RoomEndpoint endpoint)
         {
-            if (DoesEndpointExist(endpoint))
+            if (!DoesEndpointExist(endpoint))
             {
-                throw new DomainRuleException(nameof(endpoint), "Endpoint already exists in room");
+                RoomEndpoints.Add(endpoint);
             }
-
-            RoomEndpoints.Add(endpoint);
         }
 
         public void RemoveEndpoint(RoomEndpoint endpoint)
         {
-            if (!DoesEndpointExist(endpoint))
+            if (DoesEndpointExist(endpoint))
             {
-                throw new DomainRuleException(nameof(endpoint), "Endpoint does not exist in room");
+                var existingParticipant = RoomEndpoints.Single(x => x.EndpointId == endpoint.EndpointId);
+
+                RoomEndpoints.Remove(existingParticipant);
+                UpdateStatus();
             }
-
-            var existingParticipant = RoomEndpoints.Single(x => x.EndpointId == endpoint.EndpointId);
-
-            RoomEndpoints.Remove(existingParticipant);
-            UpdateStatus();
         }
         
         public List<RoomParticipant> GetRoomParticipants()

--- a/VideoApi/VideoApi.UnitTests/Domain/Rooms/ConsultationRoomTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/Rooms/ConsultationRoomTests.cs
@@ -47,7 +47,7 @@ namespace VideoApi.UnitTests.Domain.Rooms
         }
 
         [Test]
-        public void Should_not_add_existing_participant_to_room_and_throw_exception()
+        public void Should_not_add_existing_participant_to_room_twice()
         {
             var participantId = Guid.NewGuid();
             var roomParticipant = new RoomParticipant(participantId);
@@ -55,14 +55,13 @@ namespace VideoApi.UnitTests.Domain.Rooms
             room.AddParticipant(roomParticipant);
             var beforeCount = room.RoomParticipants.Count;
 
-            Action action = () => room.AddParticipant(roomParticipant);
-
-            action.Should().Throw<DomainRuleException>();
+            room.AddParticipant(roomParticipant);
+            
             room.RoomParticipants.Count.Should().Be(beforeCount);
         }
 
         [Test]
-        public void Should_not_add_existing_endpoint_to_room_and_throw_exception()
+        public void Should_not_add_existing_endpoint_to_room_twice()
         {
             var endpointId = Guid.NewGuid();
             var roomEndpoint = new RoomEndpoint(endpointId);
@@ -70,9 +69,8 @@ namespace VideoApi.UnitTests.Domain.Rooms
             room.AddEndpoint(roomEndpoint);
             var beforeCount = room.RoomEndpoints.Count;
 
-            Action action = () => room.AddEndpoint(roomEndpoint);
-
-            action.Should().Throw<DomainRuleException>();
+            room.AddEndpoint(roomEndpoint);
+            
             room.RoomEndpoints.Count.Should().Be(beforeCount);
         }
 
@@ -102,37 +100,6 @@ namespace VideoApi.UnitTests.Domain.Rooms
             room.RemoveEndpoint(roomEndpoint);
 
             room.RoomEndpoints.Count.Should().Be(beforeCount - 1);
-        }
-
-        [Test]
-        public void Should_throw_exception_for_remove_non_existing_participant_from_room()
-        {
-            var participantId = Guid.NewGuid();
-            var roomParticipant = new RoomParticipant(participantId);
-            var room = new ConsultationRoom(Guid.NewGuid(), "Room1", VirtualCourtRoomType.JudgeJOH, false);
-            room.AddParticipant(roomParticipant);
-            var beforeCount = room.RoomParticipants.Count;
-
-            Action action = () => room.RemoveParticipant(new RoomParticipant(Guid.NewGuid()));
-
-            action.Should().Throw<DomainRuleException>();
-            room.RoomParticipants.Count.Should().Be(beforeCount);
-        }
-
-
-        [Test]
-        public void Should_throw_exception_for_remove_non_existing_endpoint_from_room()
-        {
-            var endpointId = Guid.NewGuid();
-            var roomEndpoint = new RoomEndpoint(endpointId);
-            var room = new ConsultationRoom(Guid.NewGuid(), "Room1", VirtualCourtRoomType.Participant, false);
-            room.AddEndpoint(roomEndpoint);
-            var beforeCount = room.RoomEndpoints.Count;
-
-            Action action = () => room.RemoveEndpoint(new RoomEndpoint(Guid.NewGuid()));
-
-            action.Should().Throw<DomainRuleException>();
-            room.RoomEndpoints.Count.Should().Be(beforeCount);
         }
 
         [Test]


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-7167

### Change description ###

Hearings can be stuck in a broken state if events do not come in the expected sequence (i.e. join, disconnect and then join again). The event handlers should aim to be idempotent.
* Exceptions have been removed from the add and remove from room methods. 
* The room will only add if a participant/endpoint **does not** exist
* The room will only remove a participant if a participant/endpoint **does** exist

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
