### PR TITLE
VIH-7194 remove room id from TransferParticipantRequest.cs

### DIFF
--- a/VideoApi/VideoApi.Contract/Requests/TransferParticipantRequest.cs
+++ b/VideoApi/VideoApi.Contract/Requests/TransferParticipantRequest.cs
@@ -20,12 +20,7 @@ namespace VideoApi.Contract.Requests
         /// Participant Id
         /// </summary>
         public Guid? ParticipantId { get; set; }
-        
-        /// <summary>
-        /// Room Id
-        /// </summary>
-        public long? RoomId { get; set; }
-        
+
         /// <summary>
         /// Direction of transfer in regards to a conference
         /// </summary>

--- a/VideoApi/VideoApi.UnitTests/Validation/TransferParticipantRequestValidationTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Validation/TransferParticipantRequestValidationTests.cs
@@ -11,7 +11,7 @@ namespace VideoApi.UnitTests.Validation
     public class TransferParticipantRequestValidationTests
     {
         private TransferParticipantRequestValidation _validator;
-        
+
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
@@ -19,7 +19,7 @@ namespace VideoApi.UnitTests.Validation
         }
 
         [Test]
-        public async Task should_pass_validation_when_participant_id_is_set()
+        public async Task should_pass_validation()
         {
             var request = new TransferParticipantRequest
             {
@@ -30,48 +30,20 @@ namespace VideoApi.UnitTests.Validation
 
             result.IsValid.Should().BeTrue();
         }
-        
-        [Test]
-        public async Task should_pass_validation_when_room_id_is_set()
-        {
-            var request = new TransferParticipantRequest
-            {
-                RoomId = 1027,
-                TransferType = TransferType.Call
-            };
-            var result = await _validator.ValidateAsync(request);
 
-            result.IsValid.Should().BeTrue();
-        }
-        
         [Test]
-        public async Task should_fail_validation_when_participant_id_is_invalid_and_room_id_is_null()
+        public async Task should_fail_validation_when_participant_id_is_invalid()
         {
             var request = new TransferParticipantRequest
             {
                 ParticipantId = Guid.Empty,
-                RoomId = null,
                 TransferType = TransferType.Call
             };
             var result = await _validator.ValidateAsync(request);
             result.Errors.Any(x => x.ErrorMessage == TransferParticipantRequestValidation.MissingParticipantId)
                 .Should().BeTrue();
         }
-        
-        [Test]
-        public async Task should_fail_validation_when_room_id_is_negative_and_participant_id_is_null()
-        {
-            var request = new TransferParticipantRequest
-            {
-                ParticipantId = null,
-                RoomId = -3837,
-                TransferType = TransferType.Call
-            };
-            var result = await _validator.ValidateAsync(request);
-            result.Errors.Any(x => x.ErrorMessage == TransferParticipantRequestValidation.MissingParticipantId)
-                .Should().BeTrue();
-        }
-        
+
         [Test]
         public async Task should_fail_validation_when_transfer_type_is_invalid()
         {

--- a/VideoApi/VideoApi/Controllers/ConsultationController.cs
+++ b/VideoApi/VideoApi/Controllers/ConsultationController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSwag.Annotations;

--- a/VideoApi/VideoApi/Validations/TransferParticipantRequestValidation.cs
+++ b/VideoApi/VideoApi/Validations/TransferParticipantRequestValidation.cs
@@ -6,16 +6,12 @@ namespace VideoApi.Validations
 {
     public class TransferParticipantRequestValidation : AbstractValidator<TransferParticipantRequest>
     {
-        public const string MissingParticipantId = "ParticipantId or RoomId is required";
+        public const string MissingParticipantId = "ParticipantId is required";
         public const string MissingTransferType = "TransferType is required";
 
         public TransferParticipantRequestValidation()
         {
-            RuleFor(x => x.ParticipantId)
-                .NotEqual(Guid.Empty).WithMessage(MissingParticipantId)
-                .NotEmpty().When(x => !x.RoomId.HasValue).WithMessage(MissingParticipantId);
-            RuleFor(x => x.RoomId)
-                .GreaterThan(0).When(x => !x.ParticipantId.HasValue).WithMessage(MissingParticipantId);
+            RuleFor(x => x.ParticipantId).NotEqual(Guid.Empty).WithMessage(MissingParticipantId);
             RuleFor(x => x.TransferType).NotEmpty().WithMessage(MissingTransferType).WithMessage(MissingTransferType);
         }
     }


### PR DESCRIPTION
Determine the Kinly participant ID internally

### JIRA link (if applicable) ###

VIH-7194

### Change description ###

* remove room id from TransferParticipantRequest.cs
* Determine the Kinly participant ID internally like consultation service

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
