### PR TITLE
VIH-8406 clear conference instant message history

### DIFF
--- a/VideoApi/VideoApi.AcceptanceTests/Features/InstantMessages.feature
+++ b/VideoApi/VideoApi.AcceptanceTests/Features/InstantMessages.feature
@@ -25,7 +25,7 @@ Given I have a conference
 And the conference has existing messages
 And I have a remove messages from a conference request
 When I send the request to the endpoint
-Then the response should have the status NoContent and success status True
+Then the response should have the status OK and success status True
 And the chat messages are deleted
 
 @VIH-6021

--- a/VideoApi/VideoApi.Client/VideoApiClient.cs
+++ b/VideoApi/VideoApi.Client/VideoApiClient.cs
@@ -4866,16 +4866,6 @@ namespace VideoApi.Client
                             throw new VideoApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new VideoApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new VideoApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new VideoApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);

--- a/VideoApi/VideoApi.IntegrationTests/Features/InstantMessages.feature
+++ b/VideoApi/VideoApi.IntegrationTests/Features/InstantMessages.feature
@@ -32,13 +32,13 @@ Feature: Instant Messages
     And the conference has messages
     Given I have a valid delete messages from a conference request
     When I send the request to the endpoint
-    Then the response should have the status NoContent and success status True
+    Then the response should have the status OK and success status True
     And the messages have been deleted
 
   Scenario: Delete instant messages for a non-existent conference
     Given I have a nonexistent delete messages from a conference request
     When I send the request to the endpoint
-    Then the response should have the status NoContent and success status True
+    Then the response should have the status OK and success status True
 
   Scenario: Delete instant messages for an invalid conference request
     Given I have an invalid delete messages from a conference request
@@ -80,14 +80,14 @@ Feature: Instant Messages
     And the conference has messages
     And I have an nonexistent delete messages from a conference request
     When I send the request to the endpoint
-    Then the response should have the status NoContent and success status True
+    Then the response should have the status OK and success status True
 
   Scenario: Remove instant messages for a conference successfully
     Given I have a conference
     And the conference has messages
     And I have an valid delete messages from a conference request
     When I send the request to the endpoint
-    Then the response should have the status NoContent and success status True
+    Then the response should have the status OK and success status True
 
   Scenario: Get instant messages for participants
     Given I have a conference

--- a/VideoApi/VideoApi.UnitTests/Controllers/InstantMessage/InstantMessageControllerTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/InstantMessage/InstantMessageControllerTests.cs
@@ -58,8 +58,8 @@ namespace VideoApi.UnitTests.Controllers.InstantMessage
         {
             var result = await _instantMessageController.RemoveInstantMessagesForConferenceAsync(Guid.NewGuid());
 
-            var typedResult = (NoContentResult)result;
-            typedResult.StatusCode.Should().Be((int)HttpStatusCode.NoContent);
+            var typedResult = (OkObjectResult)result;
+            typedResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             _commandHandler.Verify(c => c.Handle(It.IsAny<RemoveInstantMessagesForConferenceCommand>()), Times.Once);
         }
         

--- a/VideoApi/VideoApi.UnitTests/Controllers/InstantMessage/InstantMessageControllerTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/InstantMessage/InstantMessageControllerTests.cs
@@ -58,7 +58,7 @@ namespace VideoApi.UnitTests.Controllers.InstantMessage
         {
             var result = await _instantMessageController.RemoveInstantMessagesForConferenceAsync(Guid.NewGuid());
 
-            var typedResult = (OkObjectResult)result;
+            var typedResult = (OkResult)result;
             typedResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             _commandHandler.Verify(c => c.Handle(It.IsAny<RemoveInstantMessagesForConferenceCommand>()), Times.Once);
         }

--- a/VideoApi/VideoApi/Controllers/InstantMessageController.cs
+++ b/VideoApi/VideoApi/Controllers/InstantMessageController.cs
@@ -110,7 +110,8 @@ namespace VideoApi.Controllers
             {
                 var command = new RemoveInstantMessagesForConferenceCommand(conferenceId);
                 await _commandHandler.Handle(command);
-                return Ok("InstantMessage deleted");
+                _logger.LogDebug("InstantMessage deleted");
+                return Ok();
             }
             catch (Exception e)
             {

--- a/VideoApi/VideoApi/Controllers/InstantMessageController.cs
+++ b/VideoApi/VideoApi/Controllers/InstantMessageController.cs
@@ -102,7 +102,6 @@ namespace VideoApi.Controllers
         [OpenApiOperation("RemoveInstantMessages")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<IActionResult> RemoveInstantMessagesForConferenceAsync(Guid conferenceId)
 
         {
@@ -111,7 +110,7 @@ namespace VideoApi.Controllers
             {
                 var command = new RemoveInstantMessagesForConferenceCommand(conferenceId);
                 await _commandHandler.Handle(command);
-                return NoContent();
+                return Ok("InstantMessage deleted");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-8406

### Change description ###
This change is to fix the error showing in app insights. An azure function, called ClearConferenceInstantMessageHIstory, is triggered every hour. (Please see image's attached to ticket).  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
