### PR TITLE
VIH-9317 Update Kinly callback uri for SDS

### DIFF
--- a/charts/vh-video-api/Chart.yaml
+++ b/charts/vh-video-api/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: vh-video-api
 home: https://github.com/hmcts/vh-video-api
-version: 0.0.8
+version: 0.0.9
 description: Helm Chart for Video Hearing video-api
 maintainers:
   - name: VH Devops 

--- a/charts/vh-video-api/values.yaml
+++ b/charts/vh-video-api/values.yaml
@@ -75,9 +75,9 @@ java:
         - QuickLinks--ValidAudience
   environment:
     ASPNETCORE_URLS: http://+:8080
-    KINLYCONFIGURATION__CALLBACKURI: https://vh-video-api.{{ .Values.global.environment }}.platform.hmcts.net/callback
+    KINLYCONFIGURATION__CALLBACKURI: https://vh-video-web.{{ .Values.global.environment }}.platform.hmcts.net/callback
     Logging__LogLevel__Default: debug
     Logging__LogLevel__Microsoft: debug
     Logging__LogLevel__System: debug
-    SERVICES__CALLBACKURI: https://vh-video-api.{{ .Values.global.environment }}.platform.hmcts.net/callback
+    SERVICES__CALLBACKURI: https://vh-video-web.{{ .Values.global.environment }}.platform.hmcts.net/callback
     UseStub: false


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9317


### Change description ###
Updates the kinly callback uri to fix issues connecting to hearings in SDS. Sets it to the video web callback API url, same as in non-SDS


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
