### PR TITLE
VIH-9381 Fix incorrect app setting name for conference numbers in SDS

### DIFF
--- a/charts/vh-video-api/Chart.yaml
+++ b/charts/vh-video-api/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: vh-video-api
 home: https://github.com/hmcts/vh-video-api
-version: 0.0.9
+version: 0.0.10
 description: Helm Chart for Video Hearing video-api
 maintainers:
   - name: VH Devops 

--- a/charts/vh-video-api/values.yaml
+++ b/charts/vh-video-api/values.yaml
@@ -62,8 +62,10 @@ java:
         - kinlyconfiguration--apisecret
         - kinlyconfiguration--callbacksecret
         - kinlyconfiguration--selftestapisecret
-        - kinlyconfiguration--telephoneconferencenumber
-        - kinlyconfiguration--telephoneconferencenumberwelsh
+        - name: kinlyconfiguration--telephoneconferencenumber
+          alias: kinlyconfiguration--conferencenumber
+        - name: kinlyconfiguration--telephoneconferencenumberwelsh
+          alias: kinlyconfiguration--conferencenumberwelsh
         - kinlyconfiguration--kinlyapiurl
         - kinlyconfiguration--kinlyselftestapiurl
         - kinlyconfiguration--conferenceusername


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9381


### Change description ###
Fixes incorrect name for the conference number app settings. Added an alias so that they match the names expected by the application

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
