### PR TITLE
VIH-9467 Increased recording alerts being sent to JudgeClerk since hotfix

### DIFF
--- a/VideoApi/VideoApi.Services/AudioPlatformService.cs
+++ b/VideoApi/VideoApi.Services/AudioPlatformService.cs
@@ -21,7 +21,7 @@ namespace VideoApi.Services
         private readonly ILogger<AudioPlatformService> _logger;
         private readonly IWowzaHttpClient _loadBalancerClient;
 
-        public AudioPlatformService(IWowzaHttpClient[] wowzaClients, WowzaConfiguration configuration, ILogger<AudioPlatformService> logger)
+        public AudioPlatformService(IEnumerable<IWowzaHttpClient> wowzaClients, WowzaConfiguration configuration, ILogger<AudioPlatformService> logger)
         {
             _wowzaClients       = wowzaClients.Where(e => !e.IsLoadBalancer).ToArray();
             _loadBalancerClient = wowzaClients.First(e => e.IsLoadBalancer);

--- a/VideoApi/VideoApi.Services/AudioPlatformService.cs
+++ b/VideoApi/VideoApi.Services/AudioPlatformService.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using VideoApi.Common.Configuration;
 using VideoApi.Contract.Responses;
 using VideoApi.Services.Contracts;
@@ -19,13 +21,13 @@ namespace VideoApi.Services
         private readonly ILogger<AudioPlatformService> _logger;
         private readonly IWowzaHttpClient _loadBalancerClient;
 
-        public AudioPlatformService(IEnumerable<IWowzaHttpClient> wowzaClients, WowzaConfiguration configuration, ILogger<AudioPlatformService> logger)
+        public AudioPlatformService(IWowzaHttpClient[] wowzaClients, WowzaConfiguration configuration, ILogger<AudioPlatformService> logger)
         {
-            _wowzaClients = wowzaClients.ToArray();
-            _loadBalancerClient = _wowzaClients.First(e => e.IsLoadBalancer);
-            _configuration = configuration;
-            _logger = logger;
-            ApplicationName = configuration.ApplicationName;
+            _wowzaClients       = wowzaClients.Where(e => !e.IsLoadBalancer).ToArray();
+            _loadBalancerClient = wowzaClients.First(e => e.IsLoadBalancer);
+            _configuration      = configuration;
+            _logger             = logger;
+            ApplicationName     = configuration.ApplicationName;
         }
 
         public async Task<WowzaGetApplicationResponse> GetAudioApplicationInfoAsync(Guid? hearingId = null)
@@ -38,7 +40,7 @@ namespace VideoApi.Services
                     .ToList();
 
                 var response = await WaitAnyFirstValidResult(tasks);
-
+ 
                 _logger.LogInformation("Got Wowza application info: {AppName}", applicationName);
 
                 return response;
@@ -75,24 +77,28 @@ namespace VideoApi.Services
             }
         }
 
-        public async Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(Guid hearingId)
+        public async Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(string application, string recorder)
         {
+            var responses = new List<HttpResponseMessage>();
             try
             {
-                var tasks = _wowzaClients
-                    .Select(x => x.GetStreamRecorderAsync(ApplicationName, _configuration.ServerName, _configuration.HostName, hearingId.ToString()))
-                    .ToList();
-
-                var response = await WaitAnyFirstValidResult(tasks);
-
-                _logger.LogInformation("Got Wowza stream recorder for application: {hearingId}", hearingId);
-
-                return response;
+                foreach (var client in _wowzaClients)
+                    responses.Add(await client.GetStreamRecorderAsync(application, _configuration.ServerName, _configuration.HostName, recorder));
+                responses.Remove(null);
+                
+                if (responses.All(e => !e.IsSuccessStatusCode)) 
+                {
+                    var errorMessage = await responses.First().Content.ReadAsStringAsync();
+                    throw new AudioPlatformException(errorMessage, responses.First().StatusCode);
+                }
+                var successfulResponse = responses.First(e => e.IsSuccessStatusCode);
+                _logger.LogInformation("Got Wowza stream recorder for application: {recorder}", recorder);
+                return JsonConvert.DeserializeObject<WowzaGetStreamRecorderResponse>(await successfulResponse.Content.ReadAsStringAsync());
             }
             catch (AudioPlatformException ex)
             {
-                var errorMessageTemplate = "Failed to get the Wowza stream recorder for application: {hearingId}, StatusCode: {ex.StatusCode}, Error: {ex.Message}";                
-                LogError(ex, errorMessageTemplate, hearingId, ex.StatusCode, ex.Message);
+                var errorMessageTemplate = "Failed to get the Wowza stream recorder for: {recorder}, StatusCode: {ex.StatusCode}, Error: {ex.Message}";                
+                LogError(ex, errorMessageTemplate, recorder, ex.StatusCode, ex.Message);
                 return null;
             }
         }

--- a/VideoApi/VideoApi.Services/AudioPlatformServiceStub.cs
+++ b/VideoApi/VideoApi.Services/AudioPlatformServiceStub.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Threading.Tasks;
@@ -52,10 +51,10 @@ namespace VideoApi.Services
             });
         }
 
-        
-        public async Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(Guid hearingId)
+        public async Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(string application, string recorder)
         {
-            if (!hearingId.Equals(_audioRecordingTestIdConfiguration.Existing))
+            var hearingID = new Guid(recorder);
+            if (!hearingID.Equals(_audioRecordingTestIdConfiguration.Existing))
             {
                 return await Task.FromResult<WowzaGetStreamRecorderResponse>(null);
             }
@@ -66,12 +65,6 @@ namespace VideoApi.Services
                 RecordingStartTime = DateTime.UtcNow.AddMinutes(-1).ToString("s")
             });
         }
-
-        public async Task<AudioPlatformServiceResponse> DeleteAudioStreamAsync(Guid hearingId)
-        {
-            return await DeleteAudioApplicationAsync(hearingId);
-        }
-
         public async Task<bool> GetDiagnosticsAsync()
         {
             return await Task.FromResult(true);

--- a/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
@@ -248,7 +248,7 @@ namespace VideoApi.Services.Clients
             }
         }
 
-        private class CreateApplicationRequest
+        private sealed class CreateApplicationRequest
         {
             public string AppType { get; set; }
             public string Name { get; set; }
@@ -259,7 +259,7 @@ namespace VideoApi.Services.Clients
             public SecurityConfigRequest SecurityConfig { get; set; }
         }
 
-        private class AddStreamRecorderRequest
+        private sealed class AddStreamRecorderRequest
         {
             public string RecorderName { get; set; }
             public bool StartOnKeyFrame { get; set; }
@@ -273,7 +273,7 @@ namespace VideoApi.Services.Clients
             public bool SplitOnTcDiscontinuity { get; set; }
         }
 
-        private class StreamConfigurationConfig
+        private sealed class StreamConfigurationConfig
         {
             public bool StorageDirExists { get; set; }
             public bool CreateStorageDir { get; set; }
@@ -281,7 +281,7 @@ namespace VideoApi.Services.Clients
             public string StorageDir { get; set; }
         }
 
-        private class SecurityConfigRequest
+        private sealed class SecurityConfigRequest
         {
             /// <summary>
             /// Comma separated string
@@ -291,13 +291,13 @@ namespace VideoApi.Services.Clients
             public bool PublishBlockDuplicateStreamNames { get; set; }
         }
 
-        private class ApplicationConfigAdvRequest
+        private sealed class ApplicationConfigAdvRequest
         {
             public AdvancedSetting[] AdvancedSettings { get; set; }
             public ModuleConfig[] Modules { get; set; }
         }
 
-        private class AdvancedSetting
+        private sealed class AdvancedSetting
         {
             public string SectionName { get; set; }
             public string Section { get; set; }
@@ -308,7 +308,7 @@ namespace VideoApi.Services.Clients
             public bool Enabled { get; set; }
         }
 
-        private class ModuleConfig
+        private sealed class ModuleConfig
         {
             public string Name { get; set; }
             public string Description { get; set; }

--- a/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
@@ -206,25 +206,20 @@ namespace VideoApi.Services.Clients
             return JsonConvert.DeserializeObject<WowzaGetApplicationResponse>(await response.Content.ReadAsStringAsync());
         }
 
-        public async Task<WowzaGetStreamRecorderResponse> GetStreamRecorderAsync(string applicationName, string server, string host, string hearingId)
+        public async Task<HttpResponseMessage> GetStreamRecorderAsync(string applicationName, string server, string host, string recorder)
         {
-            var response = await _httpClient.GetAsync
+            return await _httpClient.GetAsync
             (
-                $"v2/servers/{server}/vhosts/{host}/applications/" +
-                $"{applicationName}/instances/_definst_/streamrecorders/{hearingId}"
+                $"v2/servers/{server}/vhosts/{host}/applications/{applicationName}/instances/_definst_/streamrecorders/{recorder}"
             );
-
-            await HandleUnsuccessfulResponse(response);
-
-            return JsonConvert.DeserializeObject<WowzaGetStreamRecorderResponse>(await response.Content.ReadAsStringAsync());
         }
 
-        public async Task StopStreamRecorderAsync(string applicationName, string server, string host, string hearingId)
+        public async Task StopStreamRecorderAsync(string applicationName, string server, string host, string recorder)
         {
             var response = await _httpClient.PutAsync
             (
                 $"v2/servers/{server}/vhosts/{host}/applications/" +
-                $"{applicationName}/instances/_definst_/streamrecorders/{hearingId}/actions/stopRecording",
+                $"{applicationName}/instances/_definst_/streamrecorders/{recorder}/actions/stopRecording",
                 new StringContent("")
             );
 

--- a/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -214,12 +213,12 @@ namespace VideoApi.Services.Clients
             );
         }
 
-        public async Task StopStreamRecorderAsync(string applicationName, string server, string host, string recorder)
+        public async Task StopStreamRecorderAsync(string applicationName, string server, string host, string hearingId)
         {
             var response = await _httpClient.PutAsync
             (
                 $"v2/servers/{server}/vhosts/{host}/applications/" +
-                $"{applicationName}/instances/_definst_/streamrecorders/{recorder}/actions/stopRecording",
+                $"{applicationName}/instances/_definst_/streamrecorders/{hearingId}/actions/stopRecording",
                 new StringContent("")
             );
 

--- a/VideoApi/VideoApi.Services/Contracts/IAudioPlatformService.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IAudioPlatformService.cs
@@ -10,7 +10,7 @@ namespace VideoApi.Services.Contracts
         Task<WowzaGetApplicationResponse> GetAudioApplicationInfoAsync(Guid? hearingId = null);   
         Task<AudioPlatformServiceResponse> DeleteAudioApplicationAsync(Guid hearingId);        
         Task<WowzaMonitorStreamResponse> GetAudioStreamMonitoringInfoAsync(Guid hearingId);        
-        Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(Guid hearingId);
+        Task<WowzaGetStreamRecorderResponse> GetAudioStreamInfoAsync(string application, string recorder);
         public string GetAudioIngestUrl(string hearingId);
         public string ApplicationName { get; }
         Task<bool> GetDiagnosticsAsync();

--- a/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
@@ -6,7 +6,7 @@ namespace VideoApi.Services.Contracts
 {
     public interface IWowzaHttpClient
     {
-        public bool IsLoadBalancer { get; }
+        public bool IsLoadBalancer { get; set; }
         Task DeleteApplicationAsync(string applicationName, string server, string host);
         Task<WowzaMonitorStreamResponse> MonitoringStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<WowzaGetApplicationResponse> GetApplicationAsync(string applicationName, string server, string host);

--- a/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
@@ -10,7 +10,7 @@ namespace VideoApi.Services.Contracts
         Task DeleteApplicationAsync(string applicationName, string server, string host);
         Task<WowzaMonitorStreamResponse> MonitoringStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<WowzaGetApplicationResponse> GetApplicationAsync(string applicationName, string server, string host);
-        Task<WowzaGetStreamRecorderResponse> GetStreamRecorderAsync(string applicationName, string server, string host, string hearingId); 
+        Task<HttpResponseMessage> GetStreamRecorderAsync(string applicationName, string server, string host, string recorder); 
         Task StopStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<HttpResponseMessage> GetDiagnosticsAsync(string server);
     }

--- a/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
@@ -6,12 +6,12 @@ namespace VideoApi.Services.Contracts
 {
     public interface IWowzaHttpClient
     {
-        public bool IsLoadBalancer { get; set; }
+        public bool IsLoadBalancer { get; }
         Task DeleteApplicationAsync(string applicationName, string server, string host);
         Task<WowzaMonitorStreamResponse> MonitoringStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<WowzaGetApplicationResponse> GetApplicationAsync(string applicationName, string server, string host);
         Task<HttpResponseMessage> GetStreamRecorderAsync(string applicationName, string server, string host, string recorder); 
-        Task StopStreamRecorderAsync(string applicationName, string server, string host, string recorder);
+        Task StopStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<HttpResponseMessage> GetDiagnosticsAsync(string server);
     }
 }

--- a/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IWowzaHttpClient.cs
@@ -11,7 +11,7 @@ namespace VideoApi.Services.Contracts
         Task<WowzaMonitorStreamResponse> MonitoringStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
         Task<WowzaGetApplicationResponse> GetApplicationAsync(string applicationName, string server, string host);
         Task<HttpResponseMessage> GetStreamRecorderAsync(string applicationName, string server, string host, string recorder); 
-        Task StopStreamRecorderAsync(string applicationName, string server, string host, string hearingId);
+        Task StopStreamRecorderAsync(string applicationName, string server, string host, string recorder);
         Task<HttpResponseMessage> GetDiagnosticsAsync(string server);
     }
 }

--- a/VideoApi/VideoApi.UnitTests/Controllers/AudioRecording/AudioRecordingControllerTest.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/AudioRecording/AudioRecordingControllerTest.cs
@@ -232,7 +232,7 @@ namespace VideoApi.UnitTests.Controllers.AudioRecording
         public async Task GetAudioStreamInfoAsync_Returns_NotFound()
         {
             _audioPlatformService
-                .Setup(x => x.GetAudioStreamInfoAsync(It.IsAny<Guid>()))
+                .Setup(x => x.GetAudioStreamInfoAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((WowzaGetStreamRecorderResponse) null);
             
             var result = await _controller.GetAudioStreamInfoAsync(It.IsAny<Guid>()) as NotFoundResult;
@@ -263,7 +263,7 @@ namespace VideoApi.UnitTests.Controllers.AudioRecording
             };
             
             _audioPlatformService
-                .Setup(x => x.GetAudioStreamInfoAsync(It.IsAny<Guid>()))
+                .Setup(x => x.GetAudioStreamInfoAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(wowzaResponse);
             
             var result = await _controller.GetAudioStreamInfoAsync(It.IsAny<Guid>()) as OkObjectResult;

--- a/VideoApi/VideoApi/Controllers/AudioRecordingController.cs
+++ b/VideoApi/VideoApi/Controllers/AudioRecordingController.cs
@@ -132,7 +132,7 @@ namespace VideoApi.Controllers
                 ? _audioPlatformService.ApplicationName 
                 : hearingId.ToString();
             
-            var response   = await _audioPlatformService.GetAudioStreamInfoAsync(applicationName, hearingId.ToString());
+            var response = await _audioPlatformService.GetAudioStreamInfoAsync(applicationName, hearingId.ToString());
 
             if (response == null) return NotFound();
 

--- a/VideoApi/VideoApi/Controllers/AudioRecordingController.cs
+++ b/VideoApi/VideoApi/Controllers/AudioRecordingController.cs
@@ -91,9 +91,7 @@ namespace VideoApi.Controllers
 
             try
             {
-                var conference = await _queryHandler.Handle<GetConferenceByHearingRefIdQuery, Conference>(new GetConferenceByHearingRefIdQuery(hearingId));
-                if (conference == null)
-                    throw new ConferenceNotFoundException(hearingId);
+                var conference = await GetConference(hearingId);
 
                 //Hearings recorded to single app instance to be skipped (only one shared application, so cant be deleted)
                 if (conference.IngestUrl.Contains(_audioPlatformService.ApplicationName))
@@ -128,8 +126,13 @@ namespace VideoApi.Controllers
         public async Task<IActionResult> GetAudioStreamInfoAsync(Guid hearingId)
         {
             _logger.LogDebug("GetAudioStreamInfo");
-
-            var response = await _audioPlatformService.GetAudioStreamInfoAsync(hearingId);
+            
+            var conference = await GetConference(hearingId);
+            var applicationName = conference.IngestUrl.Contains(_audioPlatformService.ApplicationName) 
+                ? _audioPlatformService.ApplicationName 
+                : hearingId.ToString();
+            
+            var response   = await _audioPlatformService.GetAudioStreamInfoAsync(applicationName, hearingId.ToString());
 
             if (response == null) return NotFound();
 
@@ -304,6 +307,16 @@ namespace VideoApi.Controllers
                     throw new AudioPlatformFileNotFoundException(msg, HttpStatusCode.NotFound);
                 }
             }
+        }
+        
+        private async Task<Conference> GetConference(Guid hearingId)
+        {
+            var conference =
+                await _queryHandler
+                   .Handle<GetConferenceByHearingRefIdQuery, Conference>(new GetConferenceByHearingRefIdQuery(hearingId));
+            if (conference == null)
+                throw new ConferenceNotFoundException(hearingId);
+            return conference;
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9467

### Change description ###
- Changed wowza client GetStreamRecorderAsync to return httpResponse instead of mapping,  which is handled within the GetAudioStreamInfoAsync method. Will only return a failed response if both client responses specifically do not have 200 status codes, returns the first that does have.
- Removed loadbalancer end point from list of clients used in requests
- Updated controller to get ingest url from conference, and check for whether it is using the single app. This is then used to better direct the request for getting the wowza stream recorder

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
