### PR TITLE
VIH-9770 Fix for app not logging to app insights

### DIFF
--- a/VideoApi/VideoApi/Startup.cs
+++ b/VideoApi/VideoApi/Startup.cs
@@ -51,7 +51,7 @@ namespace VideoApi
                         .AllowCredentials();
                 }));
 
-            services.AddApplicationInsightsTelemetry(options => options.ConnectionString = Configuration["ApplicationInsights:InstrumentationKey"]);
+            services.AddApplicationInsightsTelemetry(Configuration["ApplicationInsights:InstrumentationKey"]);
             services.AddApplicationInsightsTelemetryProcessor<SuccessfulDependencyProcessor>();
 
             services.AddJsonOptions();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://github.com/hmcts/vh-bookings-api/pull/613


### Change description ###
Reverts a change recently made which is causing issues sending telemetry to app insights.

This requires using an obsolete method, which is necessary until we can update the secrets to the new format.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
