### PR TITLE
VIH-9886 jvc endpoint no alerts

### DIFF
--- a/VideoApi/VideoApi.Client/VideoApiClient.cs
+++ b/VideoApi/VideoApi.Client/VideoApiClient.cs
@@ -647,7 +647,7 @@ namespace VideoApi.Client
         /// <param name="conferenceId">Id of conference</param>
         /// <param name="request">Endpoint details</param>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request);
+        System.Threading.Tasks.Task AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -656,20 +656,20 @@ namespace VideoApi.Client
         /// <param name="conferenceId">Id of conference</param>
         /// <param name="request">Endpoint details</param>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove an endpoint from a conference
         /// </summary>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress);
+        System.Threading.Tasks.Task RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
         /// Remove an endpoint from a conference
         /// </summary>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Update an endpoint's display name or assign the defence advocate
@@ -5362,7 +5362,7 @@ namespace VideoApi.Client
         /// <param name="conferenceId">Id of conference</param>
         /// <param name="request">Endpoint details</param>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request)
+        public virtual System.Threading.Tasks.Task AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request)
         {
             return AddEndpointToConferenceAsync(conferenceId, request, System.Threading.CancellationToken.None);
         }
@@ -5374,7 +5374,7 @@ namespace VideoApi.Client
         /// <param name="conferenceId">Id of conference</param>
         /// <param name="request">Endpoint details</param>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task AddEndpointToConferenceAsync(System.Guid conferenceId, AddEndpointRequest request, System.Threading.CancellationToken cancellationToken)
         {
             if (conferenceId == null)
                 throw new System.ArgumentNullException("conferenceId");
@@ -5397,7 +5397,6 @@ namespace VideoApi.Client
                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -5432,12 +5431,7 @@ namespace VideoApi.Client
                         else
                         if (status_ == 204)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<EndpointResponse>>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new VideoApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
+                            return;
                         }
                         else
                         {
@@ -5463,7 +5457,7 @@ namespace VideoApi.Client
         /// Remove an endpoint from a conference
         /// </summary>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress)
+        public virtual System.Threading.Tasks.Task RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress)
         {
             return RemoveEndpointFromConferenceAsync(conferenceId, sipAddress, System.Threading.CancellationToken.None);
         }
@@ -5473,7 +5467,7 @@ namespace VideoApi.Client
         /// Remove an endpoint from a conference
         /// </summary>
         /// <exception cref="VideoApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<EndpointResponse>> RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task RemoveEndpointFromConferenceAsync(System.Guid conferenceId, string sipAddress, System.Threading.CancellationToken cancellationToken)
         {
             if (conferenceId == null)
                 throw new System.ArgumentNullException("conferenceId");
@@ -5490,7 +5484,6 @@ namespace VideoApi.Client
                 using (var request_ = new System.Net.Http.HttpRequestMessage())
                 {
                     request_.Method = new System.Net.Http.HttpMethod("DELETE");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -5525,12 +5518,7 @@ namespace VideoApi.Client
                         else
                         if (status_ == 204)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<EndpointResponse>>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new VideoApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
+                            return;
                         }
                         else
                         {

--- a/VideoApi/VideoApi/Controllers/EndpointsController.cs
+++ b/VideoApi/VideoApi/Controllers/EndpointsController.cs
@@ -66,9 +66,8 @@ namespace VideoApi.Controllers
         /// <param name="request">Endpoint details</param>
         [HttpPost("{conferenceId}/endpoints")]
         [OpenApiOperation("AddEndpointToConference")]
-        [ProducesResponseType(typeof(IList<EndpointResponse>), (int) HttpStatusCode.NoContent)]
-        public async Task<IActionResult> AddEndpointToConference([FromRoute] Guid conferenceId,
-            [FromBody] AddEndpointRequest request)
+        [ProducesResponseType((int) HttpStatusCode.NoContent)]
+        public async Task<IActionResult> AddEndpointToConference([FromRoute] Guid conferenceId, [FromBody] AddEndpointRequest request)
         {
             _logger.LogDebug("Attempting to add endpoint {DisplayName} to conference", request.DisplayName);
             
@@ -91,7 +90,7 @@ namespace VideoApi.Controllers
         /// <returns></returns>
         [HttpDelete("{conferenceId}/endpoints/{sipAddress}")]
         [OpenApiOperation("RemoveEndpointFromConference")]
-        [ProducesResponseType(typeof(IList<EndpointResponse>), (int) HttpStatusCode.NoContent)]
+        [ProducesResponseType((int) HttpStatusCode.NoContent)]
         public async Task<IActionResult> RemoveEndpointFromConference(Guid conferenceId, string sipAddress)
         {
             _logger.LogDebug("Attempting to remove endpoint {sipAddress} from conference", sipAddress);
@@ -117,8 +116,7 @@ namespace VideoApi.Controllers
         [HttpPatch("{conferenceId}/endpoints/{sipAddress}")]
         [OpenApiOperation("UpdateDisplayNameForEndpoint")]
         [ProducesResponseType((int) HttpStatusCode.OK)]
-        public async Task<IActionResult> UpdateDisplayNameForEndpointAsync(Guid conferenceId, string sipAddress,
-            [FromBody] UpdateEndpointRequest request)
+        public async Task<IActionResult> UpdateDisplayNameForEndpointAsync(Guid conferenceId, string sipAddress, [FromBody] UpdateEndpointRequest request)
         {
             _logger.LogDebug(
                 "Attempting to update endpoint {sipAddress} with display name {DisplayName}", sipAddress, request.DisplayName);
@@ -138,13 +136,9 @@ namespace VideoApi.Controllers
 
         private async Task UpdateDisplayNameInKinly(Guid conferenceId)
         {
-            var conference =
-                await _queryHandler.Handle<GetConferenceByIdQuery, Conference>(
-                    new GetConferenceByIdQuery(conferenceId));
+            var conference = await _queryHandler.Handle<GetConferenceByIdQuery, Conference>(new GetConferenceByIdQuery(conferenceId));
             var endpointDtos = conference.GetEndpoints().Select(EndpointMapper.MapToEndpoint);
-            await _videoPlatformService.UpdateVirtualCourtRoomAsync(conference.Id,
-                conference.AudioRecordingRequired,
-                endpointDtos);
+            await _videoPlatformService.UpdateVirtualCourtRoomAsync(conference.Id, conference.AudioRecordingRequired, endpointDtos);
         }
     }
 }

--- a/azure-pipelines.sds.pr-release.yml
+++ b/azure-pipelines.sds.pr-release.yml
@@ -96,12 +96,8 @@ stages:
         steps:
           - template: templates\dotnet\publish-acceptance-tests.yml@azTemplates
             parameters:
-              netVersion: 6.x
+              vstsFeedId: "${{ variables.nuget_org_name }}/${{ variables.nuget_feed_name }}"
               coreProjectPath: $(projectPath)
-              nugetProjectPath: $(projectPath)
-              nugetConfigPath: ${{ variables.appName }}
-              useNugetConfig: true
-
   #####################################################
   # Build Docker Image. ###############################
   - stage: Dock

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -42,11 +42,8 @@ stages:
     steps:
     - template: templates\dotnet\publish-acceptance-tests.yml@azTemplates
       parameters:
-        netVersion: 6.x
+        vstsFeedId: "${{ variables.nuget_org_name }}/${{ variables.nuget_feed_name }}"
         coreProjectPath: $(projectPath)
-        nugetProjectPath: $(projectPath)
-        nugetConfigPath: ${{ variables.appName }}
-        useNugetConfig: true
 
 #####################################################
 # Run Entity Framework Staging. #####################

--- a/charts/vh-video-api/values.dev.template.yaml
+++ b/charts/vh-video-api/values.dev.template.yaml
@@ -3,9 +3,6 @@ java:
   image: '${IMAGE_NAME}'
   ingressHost: ${SERVICE_FQDN}
   releaseNameOverride: ${RELEASE_NAME}
-  environment:
-    KINLYCONFIGURATION__CALLBACKURI: https://${RELEASE_NAME}.dev.platform.hmcts.net/callback
-    SERVICES__CALLBACKURI: https://${RELEASE_NAME}.dev.platform.hmcts.net/callback
   keyVaults:
     vh-infra-core:
       excludeEnvironmentSuffix: false

--- a/scripts/tests/run-tests.sh
+++ b/scripts/tests/run-tests.sh
@@ -10,11 +10,21 @@ dotnet test VideoApi/VideoApi.UnitTests/VideoApi.UnitTests.csproj -c $configurat
     "/p:Exclude=\"${exclusions}\"" \
     "/p:CoverletOutput=${PWD}/Coverage/" \
     "/p:MergeWith=${PWD}/Coverage/coverage.json" \
-    "/p:CoverletOutputFormat=\"opencover,json,cobertura,lcov\""
+    "/p:CoverletOutputFormat=\"opencover,json,cobertura,lcov\""  ||
+    {
+        echo "##vso[task.logissue type=error]DotNet Unit Tests Failed."
+        echo "##vso[task.complete result=Failed]"
+        exit 1
+    }
 
 dotnet test VideoApi/VideoApi.IntegrationTests/VideoApi.IntegrationTests.csproj -c $configuration --results-directory ./TestResults --logger "trx;LogFileName=VideoApi-Integration-Tests-TestResults.trx" \
     "/p:CollectCoverage=true" \
     "/p:Exclude=\"${exclusions}\"" \
     "/p:CoverletOutput=${PWD}/Coverage/" \
     "/p:MergeWith=${PWD}/Coverage/coverage.json" \
-    "/p:CoverletOutputFormat=\"opencover,json,cobertura,lcov\""
+    "/p:CoverletOutputFormat=\"opencover,json,cobertura,lcov\"" ||
+    {
+        echo "##vso[task.logissue type=error]DotNet Integration Tests Failed."
+        echo "##vso[task.complete result=Failed]"
+        exit 1
+    }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9886

### Change description ###
Fixed the return type on the OpenApi attributes, as it was generating a client that expects to return an object, when the controller actually returns 204 no content. Also include updates and fixes for the pipelines that are needed as the pipeline was failing since the nuget feed change.


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes Package will need updating in BQS
[ ] No
```
