### PR TITLE
VIH-0000 Add timeout to GetDiagnosticsAsync

### DIFF
--- a/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
@@ -229,9 +229,11 @@ namespace VideoApi.Services.Clients
 
         public async Task<HttpResponseMessage> GetDiagnosticsAsync(string server)
         {
+            using var cts = new CancellationTokenSource(new TimeSpan.FromSeconds(2));
             var response = await _httpClient.GetAsync
             (
-                $"v2/servers/{server}/status"
+                $"v2/servers/{server}/status",
+                cts.Token
             );
             
             await HandleUnsuccessfulResponse(response);

--- a/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/WowzaHttpClient.cs
@@ -229,7 +229,7 @@ namespace VideoApi.Services.Clients
 
         public async Task<HttpResponseMessage> GetDiagnosticsAsync(string server)
         {
-            using var cts = new CancellationTokenSource(new TimeSpan.FromSeconds(2));
+            using var cts = new CancellationTokenSource(new TimeSpan(0, 0, 2));
             var response = await _httpClient.GetAsync
             (
                 $"v2/servers/{server}/status",


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

The current health check for Wowza has a timeout of 100 seconds meaning that it is causing the liveliness check to fail as that will time out after 3 seconds. The change is to reduce the timeout for Wowza check to 2 seconds so it fails within the check timeout.

