### PR TITLE
VIH-0000 Fix tests in CI

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
 
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 6.0
 ENV PATH $PATH:/root/.dotnet/tools
 
 WORKDIR /app


### PR DESCRIPTION
### Change description ###
Fixes the tests that are failing in CI, due to no ef version being specified and it defaulting to ef 8 (which is not compatible with .NET 6)
