### PR TITLE
VIH-10389 Removed Defence Advocate validation

### DIFF
--- a/VideoApi/VideoApi.IntegrationTests/Features/Consultations/StartPrivateEndpointConsultation.feature
+++ b/VideoApi/VideoApi.IntegrationTests/Features/Consultations/StartPrivateEndpointConsultation.feature
@@ -32,9 +32,3 @@ Feature: Start Private Endpoint Consultation
     And I have a start endpoint consultation without a linked defence advocate
     When I send the request to the endpoint
     Then the response should have the status Unauthorized and success status False
-
-  Scenario: Fail to start a private consultation with an endpoint a not linked defence advocate
-    Given I have a conference with endpoints
-    And I have a start endpoint consultation with a not linked defence advocate
-    When I send the request to the endpoint
-    Then the response should have the status Unauthorized and success status False

--- a/VideoApi/VideoApi.UnitTests/Controllers/Consultation/StartPrivateConsultationWithEndpointTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/Consultation/StartPrivateConsultationWithEndpointTests.cs
@@ -91,27 +91,6 @@ namespace VideoApi.UnitTests.Controllers.Consultation
             actionResult.Should().NotBeNull();
             actionResult.Value.Should().Be("Endpoint does not have a defence advocate linked");
         }
-        
-        [Test]
-        public async Task should_return_unauthorised_when_endpoint_is_not_linked_with_defence_advocate()
-        {
-            var endpointWithDefenceAdvocate = TestConference.GetEndpoints().First(x => !string.IsNullOrWhiteSpace(x.DefenceAdvocate));
-            var defenceAdvocate = TestConference.GetParticipants().First(x =>
-                !x.Username.Equals(endpointWithDefenceAdvocate.DefenceAdvocate,
-                    StringComparison.CurrentCultureIgnoreCase) && x.UserRole != VideoApi.Domain.Enums.UserRole.Judge);
-            
-            var request = new EndpointConsultationRequest()
-            {
-                ConferenceId = TestConference.Id,
-                EndpointId = endpointWithDefenceAdvocate.Id,
-                RequestedById = defenceAdvocate.Id
-            };
-            var result = await Controller.StartConsultationWithEndpointAsync(request);
-
-            var actionResult = result.As<UnauthorizedObjectResult>();
-            actionResult.Should().NotBeNull();
-            actionResult.Value.Should().Be("Defence advocate is not allowed to speak to requested endpoint");
-        }
 
         [Test]
         public async Task should_return_bad_request_when_endpoint_is_already_in_room()

--- a/VideoApi/VideoApi/Controllers/ConsultationController.cs
+++ b/VideoApi/VideoApi/Controllers/ConsultationController.cs
@@ -153,13 +153,6 @@ namespace VideoApi.Controllers
                 return Unauthorized(message);
             }
 
-            if (!endpoint.DefenceAdvocate.Trim().Equals(requestedBy.Username.Trim(), StringComparison.CurrentCultureIgnoreCase))
-            {
-                const string message = "Defence advocate is not allowed to speak to requested endpoint";
-                _logger.LogWarning(message);
-                return Unauthorized(message);
-            }
-
             var roomQuery = new GetConsultationRoomByIdQuery(request.ConferenceId, request.RoomLabel);
             var room = await _queryHandler.Handle<GetConsultationRoomByIdQuery, ConsultationRoom>(roomQuery);
             if (room == null)

--- a/VideoApi/VideoApi/Controllers/ConsultationController.cs
+++ b/VideoApi/VideoApi/Controllers/ConsultationController.cs
@@ -157,7 +157,7 @@ namespace VideoApi.Controllers
             var room = await _queryHandler.Handle<GetConsultationRoomByIdQuery, ConsultationRoom>(roomQuery);
             if (room == null)
             {
-                _logger.LogWarning($"Unable to find room {request.RoomLabel}");
+                _logger.LogWarning("Unable to find room {RoomLabel}", request.RoomLabel);
                 return NotFound($"Unable to find room {request.RoomLabel}");
             }
 


### PR DESCRIPTION
Have remove the validation that checks the person adding an endpoint to a private consultation is the defence advocate. This logic is duplicated in the request via the video-web BFF and the video-api does not have acces to the participant contact email unless provided via VideoWeb