### PR TITLE
VIH-11042 push the room type and audio language to video supplier

### DIFF
--- a/VideoApi/Testing.Common/Assertions/AssertConferenceCoreResponse.cs
+++ b/VideoApi/Testing.Common/Assertions/AssertConferenceCoreResponse.cs
@@ -33,6 +33,7 @@ namespace Testing.Common.Assertions
             }
 
             conference.ConferenceRoomType.Should().Be(conferenceRoomType);
+            conference.AudioPlaybackLanguage.Should().Be(conference.AudioPlaybackLanguage);
         }
     }
 }

--- a/VideoApi/Testing.Common/Helper/Builders/Api/BookNewConferenceRequestBuilder.cs
+++ b/VideoApi/Testing.Common/Helper/Builders/Api/BookNewConferenceRequestBuilder.cs
@@ -29,6 +29,7 @@ namespace Testing.Common.Helper.Builders.Api
                 .With(x => x.AudioRecordingRequired = false)
                 .With(x => x.Endpoints = new List<AddEndpointRequest>())
                 .With(x => x.ConferenceRoomType = ConferenceRoomType.VMR)
+                .With(x => x.AudioPlaybackLanguage = AudioPlaybackLanguage.EnglishAndWelsh)
                 .Build();
         }
 
@@ -179,6 +180,12 @@ namespace Testing.Common.Helper.Builders.Api
         public BookNewConferenceRequestBuilder WithConferenceRoomType(ConferenceRoomType roomType)
         {
             _bookNewConferenceRequest.ConferenceRoomType = roomType;
+            return this;
+        }
+        
+        public BookNewConferenceRequestBuilder WithAudioPlaybackLanguage(AudioPlaybackLanguage audioPlaybackLanguage)
+        {
+            _bookNewConferenceRequest.AudioPlaybackLanguage = audioPlaybackLanguage;
             return this;
         }
     }

--- a/VideoApi/Testing.Common/Helper/Builders/Domain/ConferenceBuilder.cs
+++ b/VideoApi/Testing.Common/Helper/Builders/Domain/ConferenceBuilder.cs
@@ -126,7 +126,7 @@ namespace Testing.Common.Helper.Builders.Domain
         
         public ConferenceBuilder WithTelephoneParticipant(string phoneNumber)
         {
-            var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), phoneNumber);
+            var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), phoneNumber, _conference);
             _conference.AddTelephoneParticipant(telephoneParticipant);
 
             return this;

--- a/VideoApi/VideoApi.AcceptanceTests/packages.lock.json
+++ b/VideoApi/VideoApi.AcceptanceTests/packages.lock.json
@@ -1855,6 +1855,7 @@
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Identity.Client": "[4.60.3, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.1, )",
           "System.Text.Json": "[8.0.4, )",
           "VideoApi.Domain": "[1.0.0, )"

--- a/VideoApi/VideoApi.Common/packages.lock.json
+++ b/VideoApi/VideoApi.Common/packages.lock.json
@@ -40,6 +40,12 @@
           "System.Diagnostics.DiagnosticSource": "6.0.1"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[9.32.0.97167, )",

--- a/VideoApi/VideoApi.Contract/Enums/AudioPlaybackLanguage.cs
+++ b/VideoApi/VideoApi.Contract/Enums/AudioPlaybackLanguage.cs
@@ -1,0 +1,8 @@
+namespace VideoApi.Contract.Enums;
+
+public enum AudioPlaybackLanguage
+{
+    EnglishAndWelsh = 1,
+    English = 2,
+    Welsh = 3
+}

--- a/VideoApi/VideoApi.Contract/Requests/BookNewConferenceRequest.cs
+++ b/VideoApi/VideoApi.Contract/Requests/BookNewConferenceRequest.cs
@@ -24,5 +24,6 @@ namespace VideoApi.Contract.Requests
         public List<AddEndpointRequest> Endpoints { get; set; }
         public Supplier Supplier { get; set; }
         public ConferenceRoomType ConferenceRoomType { get; set; }
+        public AudioPlaybackLanguage AudioPlaybackLanguage { get; set; } = AudioPlaybackLanguage.EnglishAndWelsh;
     }
 }

--- a/VideoApi/VideoApi.Contract/Requests/UpdateConferenceRequest.cs
+++ b/VideoApi/VideoApi.Contract/Requests/UpdateConferenceRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using VideoApi.Contract.Enums;
 
 namespace VideoApi.Contract.Requests
 {
@@ -12,5 +13,7 @@ namespace VideoApi.Contract.Requests
         public int ScheduledDuration { get; set; }
         public string HearingVenueName { get; set; }
         public bool AudioRecordingRequired { get; set; }
+        public ConferenceRoomType RoomType { get; set; }
+        public AudioPlaybackLanguage AudoAudioPlaybackLanguage { get; set; } = AudioPlaybackLanguage.EnglishAndWelsh;
     }
 }

--- a/VideoApi/VideoApi.Contract/Responses/ConferenceCoreResponse.cs
+++ b/VideoApi/VideoApi.Contract/Responses/ConferenceCoreResponse.cs
@@ -63,4 +63,9 @@ public class ConferenceCoreResponse
     /// The room type of the conference
     /// </summary>
     public ConferenceRoomType ConferenceRoomType { get; set; }
+
+    /// <summary>
+    /// The language for the conference used to determine the audio of the countdown language and waiting room message
+    /// </summary>
+    public AudioPlaybackLanguage AudioPlaybackLanguage { get; set; }
 }

--- a/VideoApi/VideoApi.DAL/Commands/AddTelephoneParticipantCommand.cs
+++ b/VideoApi/VideoApi.DAL/Commands/AddTelephoneParticipantCommand.cs
@@ -35,7 +35,7 @@ public class AddTelephoneParticipantCommandHandler(VideoApiDbContext context)
             throw new ConferenceNotFoundException(command.ConferenceId);
         }
 
-        var telephoneParticipant = new TelephoneParticipant(command.TelephoneParticipantId, command.TelephoneNumber);
+        var telephoneParticipant = new TelephoneParticipant(command.TelephoneParticipantId, command.TelephoneNumber, conference);
         conference.AddTelephoneParticipant(telephoneParticipant);
         await context.SaveChangesAsync();
     }

--- a/VideoApi/VideoApi.DAL/Commands/CreateConferenceCommand.cs
+++ b/VideoApi/VideoApi.DAL/Commands/CreateConferenceCommand.cs
@@ -29,11 +29,13 @@ namespace VideoApi.DAL.Commands
         public List<LinkedParticipantDto> LinkedParticipants { get; set; }
         public Supplier Supplier { get; set; }
         public ConferenceRoomType ConferenceRoomType { get; set; }
+        public AudioPlaybackLanguage AudioPlaybackLanguage { get; }
 
         public CreateConferenceCommand(Guid hearingRefId, string caseType, DateTime scheduledDateTime,
             string caseNumber, string caseName, int scheduledDuration, List<Participant> participants,
             string hearingVenueName, bool audioRecordingRequired, string ingestUrl, List<Endpoint> endpoints,
-            List<LinkedParticipantDto> linkedParticipants, Supplier supplier, ConferenceRoomType conferenceRoomType)
+            List<LinkedParticipantDto> linkedParticipants, Supplier supplier, ConferenceRoomType conferenceRoomType,
+            AudioPlaybackLanguage audioPlaybackLanguage)
         {
             HearingRefId = hearingRefId;
             CaseType = caseType;
@@ -49,6 +51,7 @@ namespace VideoApi.DAL.Commands
             LinkedParticipants = linkedParticipants;
             Supplier = supplier;
             ConferenceRoomType = conferenceRoomType;
+            AudioPlaybackLanguage = audioPlaybackLanguage;
         }
     }
 
@@ -64,8 +67,9 @@ namespace VideoApi.DAL.Commands
         public async Task Handle(CreateConferenceCommand command)
         {
             var conference = new Conference(command.HearingRefId, command.CaseType, command.ScheduledDateTime,
-                command.CaseNumber,command.CaseName, command.ScheduledDuration, command.HearingVenueName, command.AudioRecordingRequired, command.IngestUrl,
-                command.Supplier, command.ConferenceRoomType);
+                command.CaseNumber, command.CaseName, command.ScheduledDuration, command.HearingVenueName,
+                command.AudioRecordingRequired, command.IngestUrl, command.Supplier, command.ConferenceRoomType,
+                command.AudioPlaybackLanguage);
             
             foreach (var participant in command.Participants)
             {

--- a/VideoApi/VideoApi.DAL/Mappings/ConferenceMap.cs
+++ b/VideoApi/VideoApi.DAL/Mappings/ConferenceMap.cs
@@ -25,11 +25,11 @@ namespace VideoApi.DAL.Mappings
             builder.Property(x => x.ActualStartTime);
             builder.Property(x => x.CreatedDateTime);
             builder.Property<Supplier>("Supplier").HasDefaultValue(Supplier.Kinly);
+            builder.Property(x=> x.AudioPlaybackLanguage).HasDefaultValue(AudioPlaybackLanguage.EnglishAndWelsh);
 
             builder.HasMany<Participant>("Participants").WithOne().OnDelete(DeleteBehavior.Cascade);
             builder.HasMany(x => x.Endpoints).WithOne().OnDelete(DeleteBehavior.Cascade);
-            builder.HasMany<TelephoneParticipant>("TelephoneParticipants").WithOne(x => x.Conference).HasForeignKey(x => x.ConferenceId)
-                .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany<TelephoneParticipant>("TelephoneParticipants").WithOne(x => x.Conference).HasForeignKey(x => x.ConferenceId).OnDelete(DeleteBehavior.Cascade);
             builder.HasMany<ConferenceStatus>("ConferenceStatuses").WithOne().OnDelete(DeleteBehavior.Cascade);
             builder.HasMany(x => x.InstantMessageHistory).WithOne().OnDelete(DeleteBehavior.Cascade).IsRequired();
             builder.OwnsOne<MeetingRoom>("MeetingRoom").Property(x => x.AdminUri).HasColumnName("AdminUri");

--- a/VideoApi/VideoApi.DAL/Migrations/20241017154144_AddAudioPlaybackLanguageToConference.Designer.cs
+++ b/VideoApi/VideoApi.DAL/Migrations/20241017154144_AddAudioPlaybackLanguageToConference.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VideoApi.DAL;
 
@@ -11,9 +12,11 @@ using VideoApi.DAL;
 namespace VideoApi.DAL.Migrations
 {
     [DbContext(typeof(VideoApiDbContext))]
-    partial class VideoApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241017154144_AddAudioPlaybackLanguageToConference")]
+    partial class AddAudioPlaybackLanguageToConference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VideoApi/VideoApi.DAL/Migrations/20241017154144_AddAudioPlaybackLanguageToConference.cs
+++ b/VideoApi/VideoApi.DAL/Migrations/20241017154144_AddAudioPlaybackLanguageToConference.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VideoApi.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAudioPlaybackLanguageToConference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "State",
+                table: "TelephoneParticipant",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldDefaultValue: 1);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CurrentRoom",
+                table: "TelephoneParticipant",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true,
+                oldDefaultValue: 0);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ConferenceId",
+                table: "TelephoneParticipant",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AudioPlaybackLanguage",
+                table: "Conference",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AudioPlaybackLanguage",
+                table: "Conference");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "State",
+                table: "TelephoneParticipant",
+                type: "int",
+                nullable: false,
+                defaultValue: 1,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CurrentRoom",
+                table: "TelephoneParticipant",
+                type: "int",
+                nullable: true,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ConferenceId",
+                table: "TelephoneParticipant",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+        }
+    }
+}

--- a/VideoApi/VideoApi.DAL/VideoApi.DAL.csproj
+++ b/VideoApi/VideoApi.DAL/VideoApi.DAL.csproj
@@ -33,4 +33,8 @@
     <ProjectReference Include="..\VideoApi.Domain\VideoApi.Domain.csproj" />
     <ProjectReference Include="..\VideoApi.Services\VideoApi.Services.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Migrations\20241017152205_AddAudioPlaybackLanguageToConference.cs" />
+    <Compile Remove="Migrations\20241017152205_AddAudioPlaybackLanguageToConference.Designer.cs" />
+  </ItemGroup>
 </Project>

--- a/VideoApi/VideoApi.DAL/packages.lock.json
+++ b/VideoApi/VideoApi.DAL/packages.lock.json
@@ -1023,6 +1023,7 @@
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Identity.Client": "[4.60.3, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.1, )",
           "System.Text.Json": "[8.0.4, )",
           "VideoApi.Domain": "[1.0.0, )"

--- a/VideoApi/VideoApi.Domain/Conference.cs
+++ b/VideoApi/VideoApi.Domain/Conference.cs
@@ -12,7 +12,7 @@ namespace VideoApi.Domain
     {
         public Conference(Guid hearingRefId, string caseType, DateTime scheduledDateTime, string caseNumber,
             string caseName, int scheduledDuration, string hearingVenueName, bool audioRecordingRequired, string ingestUrl,
-            Supplier supplier = Supplier.Kinly, ConferenceRoomType conferenceRoomType = ConferenceRoomType.VMR)
+            Supplier supplier = Supplier.Kinly, ConferenceRoomType conferenceRoomType = ConferenceRoomType.VMR, AudioPlaybackLanguage audioPlaybackLanguage = AudioPlaybackLanguage.EnglishAndWelsh)
         {
             Id = Guid.NewGuid();
             Participants = new List<ParticipantBase>();
@@ -37,6 +37,7 @@ namespace VideoApi.Domain
             UpdatedAt = CreatedDateTime;
             Supplier = supplier;
             ConferenceRoomType = conferenceRoomType;
+            AudioPlaybackLanguage = audioPlaybackLanguage;
         }
 
         public Guid HearingRefId { get; private set; }
@@ -64,6 +65,7 @@ namespace VideoApi.Domain
         public IReadOnlyCollection<Room> Rooms => _rooms.AsReadOnly();
         public Supplier Supplier { get; private set; }
         public ConferenceRoomType ConferenceRoomType { get; private set; }
+        public AudioPlaybackLanguage AudioPlaybackLanguage { get; private set; }
         
         public void UpdateMeetingRoom(string adminUri, string judgeUri, string participantUri, string pexipNode,
             string telephoneConferenceId)

--- a/VideoApi/VideoApi.Domain/Enums/AudioPlaybackLanguage.cs
+++ b/VideoApi/VideoApi.Domain/Enums/AudioPlaybackLanguage.cs
@@ -1,0 +1,8 @@
+namespace VideoApi.Domain.Enums;
+
+public enum AudioPlaybackLanguage
+{
+    EnglishAndWelsh = 1,
+    English = 2,
+    Welsh = 3
+}

--- a/VideoApi/VideoApi.Domain/TelephoneParticipant.cs
+++ b/VideoApi/VideoApi.Domain/TelephoneParticipant.cs
@@ -6,18 +6,25 @@ namespace VideoApi.Domain;
 public class TelephoneParticipant: TrackableEntity<Guid>
 {
     public Guid ConferenceId { get; set; }
-    public Conference Conference { get; set; }
+    public virtual Conference Conference { get; set; }
     
     public TelephoneState State { get; set; }
     public RoomType? CurrentRoom { get; set; }
     public string TelephoneNumber { get; private set; }
     
-    public TelephoneParticipant(Guid id, string telephoneNumber)
+    protected TelephoneParticipant()
+    {
+        
+    }
+    
+    public TelephoneParticipant(Guid id, string telephoneNumber, Conference conference)
     {
         Id = id;
         State = TelephoneState.Connected;
         CurrentRoom = RoomType.WaitingRoom;
         TelephoneNumber = telephoneNumber;
+        Conference = conference;
+        ConferenceId = conference.Id;
     }
     
     public void UpdateStatus(TelephoneState status)

--- a/VideoApi/VideoApi.IntegrationTests/Database/Commands/CreateConferenceCommandTests.cs
+++ b/VideoApi/VideoApi.IntegrationTests/Database/Commands/CreateConferenceCommandTests.cs
@@ -11,6 +11,7 @@ using VideoApi.DAL.Exceptions;
 using VideoApi.DAL.Queries;
 using VideoApi.Domain;
 using VideoApi.Extensions;
+using AudioPlaybackLanguage = VideoApi.Domain.Enums.AudioPlaybackLanguage;
 using ConferenceRoomType = VideoApi.Domain.Enums.ConferenceRoomType;
 using Supplier = VideoApi.Domain.Enums.Supplier;
 using Task = System.Threading.Tasks.Task;
@@ -53,11 +54,12 @@ namespace VideoApi.IntegrationTests.Database.Commands
             };
             const Supplier supplier = Supplier.Vodafone;
             const ConferenceRoomType conferenceRoomType = ConferenceRoomType.VA;
+            const AudioPlaybackLanguage audioPlaybackLanguage = AudioPlaybackLanguage.English;
 
             var command =
                 new CreateConferenceCommand(hearingRefId, caseType, scheduledDateTime, caseNumber, caseName,
                     scheduledDuration, participants, hearingVenueName, audioRecordingRequired, ingestUrl, endpoints, new List<LinkedParticipantDto>(),
-                    supplier, conferenceRoomType);
+                    supplier, conferenceRoomType, audioPlaybackLanguage);
             
             await _handler.Handle(command);
 
@@ -76,11 +78,13 @@ namespace VideoApi.IntegrationTests.Database.Commands
             command.Participants[0].Should().BeEquivalentTo(participant);
             command.Supplier.Should().Be(supplier);
             command.ConferenceRoomType.Should().Be(conferenceRoomType);
+            command.AudioPlaybackLanguage.Should().Be(audioPlaybackLanguage);
             _newConferenceId = command.NewConferenceId;
             
             var conference = await _conferenceByIdHandler.Handle(new GetConferenceByIdQuery(_newConferenceId));
             conference.Should().NotBeNull();
             conference.Supplier.Should().Be(supplier);
+            conference.AudioPlaybackLanguage.Should().Be(AudioPlaybackLanguage.English);
         }
 
         [Test]
@@ -117,7 +121,7 @@ namespace VideoApi.IntegrationTests.Database.Commands
             var command =
                 new CreateConferenceCommand(hearingRefId, caseType, scheduledDateTime, caseNumber, caseName,
                     scheduledDuration, participants, hearingVenueName, audioRecordingRequired, ingestUrl, endpoints, linkedParticipants,
-                    Supplier.Kinly, ConferenceRoomType.VMR);
+                    Supplier.Kinly, ConferenceRoomType.VMR, AudioPlaybackLanguage.EnglishAndWelsh);
             
             await _handler.Handle(command);
             
@@ -175,7 +179,7 @@ namespace VideoApi.IntegrationTests.Database.Commands
             var command =
                 new CreateConferenceCommand(hearingRefId, caseType, scheduledDateTime, caseNumber, caseName,
                     scheduledDuration, participants, hearingVenueName, audioRecordingRequired, ingestUrl, endpoints, linkedParticipants,
-                    Supplier.Kinly, ConferenceRoomType.VMR);
+                    Supplier.Kinly, ConferenceRoomType.VMR, AudioPlaybackLanguage.EnglishAndWelsh);
             
             var exception = Assert.ThrowsAsync<ParticipantLinkException>(() => _handler.Handle(command));
             exception.LinkRefId.Should().Be(participantB.ParticipantRefId);

--- a/VideoApi/VideoApi.IntegrationTests/packages.lock.json
+++ b/VideoApi/VideoApi.IntegrationTests/packages.lock.json
@@ -368,6 +368,15 @@
           "Microsoft.AspNetCore.Authorization": "2.2.0"
         }
       },
+      "Microsoft.AspNetCore.Connections.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.1.10",
+          "System.IO.Pipelines": "4.7.3"
+        }
+      },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -454,6 +463,14 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
+      "Microsoft.AspNetCore.Http.Connections.Common": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
+        }
+      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -467,20 +484,11 @@
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
+        "resolved": "3.1.10",
+        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "3.1.10",
           "System.IO.Pipelines": "4.7.3"
-        }
-      },
-      "Microsoft.AspNetCore.JsonPatch": {
-        "type": "Transitive",
-        "resolved": "8.0.4",
-        "contentHash": "8iy7uza6GTuE5GadOryGfsGuA8xP1RTs16zqdXF5gM0b8iDfyNWnyDmatY5cZhXE1kJiko0S7s1T/gNFdIZ7Zg==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -767,6 +775,15 @@
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "System.Text.Json": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.KeyPerFile": {
+        "type": "Transitive",
+        "resolved": "3.1.11",
+        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.11",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
@@ -2403,6 +2420,18 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "VH.Core.Configuration": {
+        "type": "Transitive",
+        "resolved": "0.1.13",
+        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
+          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
+          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
+          "Microsoft.Extensions.DependencyModel": "3.1.6",
+          "SonarAnalyzer.CSharp": "8.2.0.14119"
+        }
+      },
       "YamlDotNet": {
         "type": "Transitive",
         "resolved": "13.7.1",
@@ -2479,6 +2508,7 @@
           "NSwag.AspNetCore": "[14.0.7, )",
           "Scrutor": "[4.2.2, )",
           "System.Text.Json": "[8.0.4, )",
+          "VH.Core.Configuration": "[0.1.13, )",
           "VideoApi.Common": "[1.0.0, )",
           "VideoApi.Contract": "[1.0.0, )",
           "VideoApi.DAL": "[1.0.0, )",
@@ -2502,6 +2532,7 @@
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Identity.Client": "[4.60.3, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.1, )",
           "System.Text.Json": "[8.0.4, )",
           "VideoApi.Domain": "[1.0.0, )"

--- a/VideoApi/VideoApi.IntegrationTests/packages.lock.json
+++ b/VideoApi/VideoApi.IntegrationTests/packages.lock.json
@@ -368,15 +368,6 @@
           "Microsoft.AspNetCore.Authorization": "2.2.0"
         }
       },
-      "Microsoft.AspNetCore.Connections.Abstractions": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
-        }
-      },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -463,14 +454,6 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections.Common": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -484,11 +467,10 @@
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
+        "resolved": "2.2.0",
+        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
+          "Microsoft.Extensions.Primitives": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -775,15 +757,6 @@
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "System.Text.Json": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Configuration.KeyPerFile": {
-        "type": "Transitive",
-        "resolved": "3.1.11",
-        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.11",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
@@ -2420,18 +2393,6 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "VH.Core.Configuration": {
-        "type": "Transitive",
-        "resolved": "0.1.13",
-        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
-          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
-          "Microsoft.Extensions.DependencyModel": "3.1.6",
-          "SonarAnalyzer.CSharp": "8.2.0.14119"
-        }
-      },
       "YamlDotNet": {
         "type": "Transitive",
         "resolved": "13.7.1",
@@ -2508,7 +2469,6 @@
           "NSwag.AspNetCore": "[14.0.7, )",
           "Scrutor": "[4.2.2, )",
           "System.Text.Json": "[8.0.4, )",
-          "VH.Core.Configuration": "[0.1.13, )",
           "VideoApi.Common": "[1.0.0, )",
           "VideoApi.Contract": "[1.0.0, )",
           "VideoApi.DAL": "[1.0.0, )",

--- a/VideoApi/VideoApi.Services/Clients/SupplierApiClient.cs
+++ b/VideoApi/VideoApi.Services/Clients/SupplierApiClient.cs
@@ -1809,6 +1809,12 @@ namespace VideoApi.Services.Clients
         [Newtonsoft.Json.JsonProperty("room_type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RoomType { get; set; }
         
+        /// <summary>
+        /// The audio play back language
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("audio_playback_language", Required = Newtonsoft.Json.Required.Default)]
+        public string AudioPlaybackLanguage { get; set; }
+        
         [Newtonsoft.Json.JsonProperty("jvs_endpoint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.List<Endpoint> Jvs_endpoint { get; set; }
         
@@ -1835,6 +1841,24 @@ namespace VideoApi.Services.Clients
         /// </summary>
         [Newtonsoft.Json.JsonProperty("recording_enabled", Required = Newtonsoft.Json.Required.Always)]
         public bool Recording_enabled { get; set; }
+        
+        /// <summary>
+        /// Should stream conference
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("streaming_enabled", Required = Newtonsoft.Json.Required.Default)]
+        public bool Streaming_enabled { get; set; }
+        
+        /// <summary>
+        /// The audio play back language
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("audio_playback_language", Required = Newtonsoft.Json.Required.Default)]
+        public string AudioPlaybackLanguage { get; set; }
+        
+        /// <summary>
+        /// Room type (either VMR or VA)
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("room_type", Required = Newtonsoft.Json.Required.Always)]
+        public string RoomType { get; set; }
 
         [Newtonsoft.Json.JsonProperty("jvs_endpoint", Required = Newtonsoft.Json.Required.Always)]
         public System.Collections.Generic.List<Endpoint> Jvs_endpoint { get; set; } = new System.Collections.Generic.List<Endpoint>();

--- a/VideoApi/VideoApi.Services/Contracts/IVideoPlatformService.cs
+++ b/VideoApi/VideoApi.Services/Contracts/IVideoPlatformService.cs
@@ -3,17 +3,29 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using VideoApi.Common.Security.Supplier.Base;
 using VideoApi.Domain;
+using VideoApi.Domain.Enums;
 using VideoApi.Services.Clients;
 using VideoApi.Services.Dtos;
 using Task = System.Threading.Tasks.Task;
-using ConferenceRoomType = VideoApi.Contract.Enums.ConferenceRoomType;
 
 namespace VideoApi.Services.Contracts
 {
     public interface IVideoPlatformService
     {
+        /// <summary>
+        /// Book a virtual courtroom
+        /// </summary>
+        /// <param name="conferenceId">The conference id</param>
+        /// <param name="audioRecordingRequired">Is the audio recording enabled</param>
+        /// <param name="ingestUrl">The ingest url used by audio recording</param>
+        /// <param name="endpoints">The JVS endpoints for the conference which includes sip address, pin and role</param>
+        /// <param name="telephoneId">The pin used by telephone participants to join a conference</param>
+        /// <param name="roomType">The type of room, VA (Virtual Auditorium for screening) or VMR</param>
+        /// <param name="audioPlaybackLanguage">The language for the conference used to determine the audio of the countdown language and waiting room message</param>
+        /// <returns></returns>
         Task<MeetingRoom> BookVirtualCourtroomAsync(Guid conferenceId, bool audioRecordingRequired, string ingestUrl,
-            IEnumerable<EndpointDto> endpoints, string telephoneId, ConferenceRoomType roomType);
+            IEnumerable<EndpointDto> endpoints, string telephoneId, ConferenceRoomType roomType,
+            AudioPlaybackLanguage audioPlaybackLanguage);
         Task<MeetingRoom> GetVirtualCourtRoomAsync(Guid conferenceId);
         Task<TestCallResult> GetTestCallScoreAsync(Guid participantId, int retryAttempts = 2);
         Task TransferParticipantAsync(Guid conferenceId, string participantId, string fromRoom, string toRoom);
@@ -23,13 +35,19 @@ namespace VideoApi.Services.Contracts
         /// <param name="conferenceId">Conference Id</param>
         /// <returns></returns>
         Task DeleteVirtualCourtRoomAsync(Guid conferenceId);
+
         /// <summary>
         /// Update virtual court room
         /// </summary>
-        /// <param name="conferenceId"></param>
-        /// <param name="audioRecordingRequired"></param>
+        /// <param name="conferenceId">The conference id</param>
+        /// <param name="audioRecordingRequired">Is the audio recording enabled</param>
+        /// <param name="endpoints">The JVS endpoints for the conference which includes sip address, pin and role</param>
+        /// <param name="roomType">The type of room, VA (Virtual Auditorium for screening) or VMR</param>
+        /// <param name="audioPlaybackLanguage">The language for the conference used to determine the audio of the countdown language and waiting room message</param>
         /// <returns></returns>
-        Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired, IEnumerable<EndpointDto> endpoints);
+        Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired,
+            IEnumerable<EndpointDto> endpoints, ConferenceRoomType roomType,
+            AudioPlaybackLanguage audioPlaybackLanguage);
 
         Task StartHearingAsync(Guid conferenceId, string triggeredByHostId,
             IEnumerable<string> participantsToForceTransfer = null, IEnumerable<string> hosts = null,

--- a/VideoApi/VideoApi.Services/SupplierPlatformService.cs
+++ b/VideoApi/VideoApi.Services/SupplierPlatformService.cs
@@ -5,8 +5,8 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using VideoApi.Common.Security.Supplier.Base;
-using VideoApi.Contract.Enums;
 using VideoApi.Domain;
+using VideoApi.Domain.Enums;
 using VideoApi.Services.Clients;
 using VideoApi.Services.Contracts;
 using VideoApi.Services.Dtos;
@@ -14,7 +14,6 @@ using VideoApi.Services.Exceptions;
 using VideoApi.Services.Mappers;
 using Task = System.Threading.Tasks.Task;
 using Supplier = VideoApi.Domain.Enums.Supplier;
-using ConferenceRoomType = VideoApi.Contract.Enums.ConferenceRoomType;
 
 namespace VideoApi.Services
 {
@@ -48,7 +47,7 @@ namespace VideoApi.Services
             bool audioRecordingRequired,
             string ingestUrl,
             IEnumerable<EndpointDto> endpoints, 
-            string telephoneId, ConferenceRoomType roomType)
+            string telephoneId, ConferenceRoomType roomType, AudioPlaybackLanguage audioPlaybackLanguage)
         {
             _logger.LogInformation(
                 "Booking a conference for {ConferenceId} with callback {CallbackUri} at {KinlyApiUrl}", conferenceId,
@@ -65,7 +64,8 @@ namespace VideoApi.Services
                     Streaming_enabled = false,
                     Streaming_url = null,
                     Jvs_endpoint = endpoints.Select(EndpointMapper.MapToEndpoint).ToList(),
-                    Telephone_Conference_id = telephoneId
+                    Telephone_Conference_id = telephoneId,
+                    AudioPlaybackLanguage = audioPlaybackLanguage.ToString()
                 });
 
                 return _supplier == Supplier.Vodafone 
@@ -146,13 +146,16 @@ namespace VideoApi.Services
         }
         
         public Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired,
-            IEnumerable<EndpointDto> endpoints)
+            IEnumerable<EndpointDto> endpoints, ConferenceRoomType roomType,
+            AudioPlaybackLanguage audioPlaybackLanguage = AudioPlaybackLanguage.EnglishAndWelsh)
         {
             return _supplierApiClient.UpdateHearingAsync(conferenceId.ToString(),
                 new UpdateHearingParams
                 {
                     Recording_enabled = audioRecordingRequired,
-                    Jvs_endpoint = endpoints.Select(EndpointMapper.MapToEndpoint).ToList()
+                    Jvs_endpoint = endpoints.Select(EndpointMapper.MapToEndpoint).ToList(),
+                    RoomType = roomType.ToString(),
+                    AudioPlaybackLanguage = audioPlaybackLanguage.ToString()
                 });
         }
 

--- a/VideoApi/VideoApi.Services/SupplierPlatformService.cs
+++ b/VideoApi/VideoApi.Services/SupplierPlatformService.cs
@@ -147,7 +147,7 @@ namespace VideoApi.Services
         
         public Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired,
             IEnumerable<EndpointDto> endpoints, ConferenceRoomType roomType,
-            AudioPlaybackLanguage audioPlaybackLanguage = AudioPlaybackLanguage.EnglishAndWelsh)
+            AudioPlaybackLanguage audioPlaybackLanguage)
         {
             return _supplierApiClient.UpdateHearingAsync(conferenceId.ToString(),
                 new UpdateHearingParams

--- a/VideoApi/VideoApi.Services/SupplierPlatformServiceStub.cs
+++ b/VideoApi/VideoApi.Services/SupplierPlatformServiceStub.cs
@@ -3,14 +3,13 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using VideoApi.Common.Security.Supplier.Base;
-using VideoApi.Contract.Enums;
 using VideoApi.Domain;
+using VideoApi.Domain.Enums;
 using VideoApi.Services.Clients;
 using VideoApi.Services.Contracts;
 using VideoApi.Services.Dtos;
 using VideoApi.Services.Exceptions;
 using Task = System.Threading.Tasks.Task;
-using ConferenceRoomType = VideoApi.Contract.Enums.ConferenceRoomType;
 
 namespace VideoApi.Services
 {
@@ -28,7 +27,8 @@ namespace VideoApi.Services
         public Task<MeetingRoom> BookVirtualCourtroomAsync(Guid conferenceId,
             bool audioRecordingRequired,
             string ingestUrl,
-            IEnumerable<EndpointDto> endpoints, string telephoneId, ConferenceRoomType roomType)
+            IEnumerable<EndpointDto> endpoints, string telephoneId, ConferenceRoomType roomType,
+            AudioPlaybackLanguage audioPlaybackLanguage)
         {
             if (_bookedGuids.Contains(conferenceId))
                 throw new DoubleBookingException(conferenceId);
@@ -58,7 +58,9 @@ namespace VideoApi.Services
             return Task.CompletedTask;
         }
         
-        public Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired, IEnumerable<EndpointDto> endpoints)
+        public Task UpdateVirtualCourtRoomAsync(Guid conferenceId, bool audioRecordingRequired, 
+            IEnumerable<EndpointDto> endpoints, ConferenceRoomType roomType,
+            AudioPlaybackLanguage audioPlaybackLanguage)
         {
             return Task.CompletedTask;
         }

--- a/VideoApi/VideoApi.UnitTests/Controllers/Conference/BookNewConferenceTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/Conference/BookNewConferenceTests.cs
@@ -89,10 +89,11 @@ namespace VideoApi.UnitTests.Controllers.Conference
             SetupCallToMockRetryService(true);
             
             await Controller.BookNewConferenceAsync(_request);
-            
+
             BookingServiceMock.Verify(v
                 => v.BookMeetingRoomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), expectedIngestUrl,
-                    It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<ConferenceRoomType>(), It.IsAny<Supplier>()), Times.Once);
+                    It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(),
+                    It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>(), It.IsAny<VideoApi.Domain.Enums.Supplier>()), Times.Once);
         }
         
         [Test]

--- a/VideoApi/VideoApi.UnitTests/Controllers/Conference/UpdateConferenceTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/Conference/UpdateConferenceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using VideoApi.Contract.Enums;
 using VideoApi.Contract.Requests;
 using VideoApi.DAL.Commands;
 using VideoApi.DAL.Exceptions;
@@ -31,11 +32,13 @@ namespace VideoApi.UnitTests.Controllers.Conference
                 .Setup(x => x.Handle<GetNonClosedConferenceByHearingRefIdQuery, List<VideoApi.Domain.Conference>>(query))
                 .ReturnsAsync(new List<VideoApi.Domain.Conference> { TestConference });
 
-            VideoPlatformServiceMock.Setup(v => v.UpdateVirtualCourtRoomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<List<EndpointDto>>()));
+            VideoPlatformServiceMock.Setup(v => v.UpdateVirtualCourtRoomAsync(It.IsAny<Guid>(), It.IsAny<bool>(),
+                It.IsAny<List<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()));
 
             await Controller.UpdateConferenceAsync(request);
-            
-            VideoPlatformServiceMock.Setup(v => v.UpdateVirtualCourtRoomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<List<EndpointDto>>()));
+
+            VideoPlatformServiceMock.Setup(v => v.UpdateVirtualCourtRoomAsync(It.IsAny<Guid>(), It.IsAny<bool>(),
+                It.IsAny<List<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()));
             CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateConferenceDetailsCommand>()), Times.Once);
             VerifySupplierUsed(TestConference.Supplier, Times.Exactly(1));
         }

--- a/VideoApi/VideoApi.UnitTests/Controllers/ConferenceManagement/ConferenceManagementControllerTestBase.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/ConferenceManagement/ConferenceManagementControllerTestBase.cs
@@ -71,7 +71,7 @@ namespace VideoApi.UnitTests.Controllers.ConferenceManagement
 
         protected void AddTelephoneParticipantToTestConference()
         {
-            TestConference.AddTelephoneParticipant(new TelephoneParticipant(Guid.NewGuid(), "Anonymous"));
+            TestConference.AddTelephoneParticipant(new TelephoneParticipant(Guid.NewGuid(), "Anonymous", TestConference));
         }
 
         protected void AddQuicklinkToTestConference()

--- a/VideoApi/VideoApi.UnitTests/Controllers/Endpoints/EndpointControllerTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Controllers/Endpoints/EndpointControllerTests.cs
@@ -106,7 +106,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
                 .Setup(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                     testConference.AudioRecordingRequired,
                     testConference.GetEndpoints()
-                        .Select(EndpointMapper.MapToEndpoint)))
+                        .Select(EndpointMapper.MapToEndpoint), testConference.ConferenceRoomType, testConference.AudioPlaybackLanguage))
                 .Returns(Task.CompletedTask);
 
             var response = await _controller.AddEndpointToConference(conferenceId, new AddEndpointRequest());
@@ -119,7 +119,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
 
             _videoPlatformServiceMock.Verify(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                 testConference.AudioRecordingRequired,
-                It.IsAny<IEnumerable<EndpointDto>>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
             VerifySupplierUsed(testConference.Supplier, Times.Exactly(1));
         }
 
@@ -153,7 +153,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
                 .Setup(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                     testConference.AudioRecordingRequired,
                     testConference.GetEndpoints()
-                        .Select(EndpointMapper.MapToEndpoint)))
+                        .Select(EndpointMapper.MapToEndpoint), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()))
                 .Returns(Task.CompletedTask);
 
             var response = await _controller.RemoveEndpointFromConference(conferenceId, "sip@sip.com");
@@ -169,7 +169,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
 
             _videoPlatformServiceMock.Verify(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                 testConference.AudioRecordingRequired,
-                It.IsAny<IEnumerable<EndpointDto>>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
             VerifySupplierUsed(testConference.Supplier, Times.Exactly(2));
         }
 
@@ -205,7 +205,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
                 .Setup(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                     testConference.AudioRecordingRequired,
                     testConference.GetEndpoints()
-                        .Select(EndpointMapper.MapToEndpoint)))
+                        .Select(EndpointMapper.MapToEndpoint), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()))
                 .Returns(Task.CompletedTask);
 
             var response = await _controller.UpdateEndpointInConference(testConference.Id, "sip@sip.com", new UpdateEndpointRequest
@@ -224,7 +224,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
 
             _videoPlatformServiceMock.Verify(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                 testConference.AudioRecordingRequired,
-                It.IsAny<IEnumerable<EndpointDto>>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
             VerifySupplierUsed(testConference.Supplier, Times.Exactly(3));
         }
 
@@ -258,7 +258,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
                 .Setup(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                     testConference.AudioRecordingRequired,
                     testConference.GetEndpoints()
-                        .Select(EndpointMapper.MapToEndpoint)))
+                        .Select(EndpointMapper.MapToEndpoint), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()))
                 .Returns(Task.CompletedTask);
 
             var response = await _controller.UpdateEndpointInConference(testConference.Id, "sip@sip.com", new UpdateEndpointRequest
@@ -277,7 +277,7 @@ namespace VideoApi.UnitTests.Controllers.Endpoints
 
             _videoPlatformServiceMock.Verify(x => x.UpdateVirtualCourtRoomAsync(testConference.Id,
                 testConference.AudioRecordingRequired,
-                It.IsAny<IEnumerable<EndpointDto>>()), Times.Never);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Never);
         }
         
         protected void VerifySupplierUsed(Supplier supplier, Times times)

--- a/VideoApi/VideoApi.UnitTests/Domain/Conference/AddTelephoneParticipantTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/Conference/AddTelephoneParticipantTests.cs
@@ -13,7 +13,7 @@ public class AddTelephoneParticipantTests
     {
         var conference = new ConferenceBuilder().Build();
         var beforeCount = conference.GetTelephoneParticipants().Count;
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         
         conference.AddTelephoneParticipant(telephoneParticipant);
         
@@ -25,7 +25,7 @@ public class AddTelephoneParticipantTests
     public void should_not_add_same_telephone_participant_twice()
     {
         var conference = new ConferenceBuilder().Build();
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         
         conference.AddTelephoneParticipant(telephoneParticipant);
         

--- a/VideoApi/VideoApi.UnitTests/Domain/Conference/RemoveTelephoneParticipantTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/Conference/RemoveTelephoneParticipantTests.cs
@@ -12,7 +12,7 @@ public class RemoveTelephoneParticipantTests
     public void should_remove_a_telephone_participant()
     {
         var conference = new ConferenceBuilder().Build();
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         
         conference.AddTelephoneParticipant(telephoneParticipant);
         
@@ -28,7 +28,7 @@ public class RemoveTelephoneParticipantTests
     public void should_not_remove_a_telephone_participant_that_does_not_exist()
     {
         var conference = new ConferenceBuilder().Build();
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         
         var action = () => conference.RemoveTelephoneParticipant(telephoneParticipant);
         

--- a/VideoApi/VideoApi.UnitTests/Domain/TelephoneParticipants/UpdateCurrentRoomTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/TelephoneParticipants/UpdateCurrentRoomTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Testing.Common.Helper.Builders.Domain;
 using VideoApi.Domain;
 using VideoApi.Domain.Enums;
 
@@ -9,7 +10,8 @@ public class UpdateCurrentRoomTests
     [Test]
     public void should_update_current_room()
     {
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var conference = new ConferenceBuilder().Build();
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         var room = RoomType.WaitingRoom;
         telephoneParticipant.UpdateCurrentRoom(room);
         telephoneParticipant.CurrentRoom.Should().Be(room);

--- a/VideoApi/VideoApi.UnitTests/Domain/TelephoneParticipants/UpdateStatusTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/TelephoneParticipants/UpdateStatusTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Testing.Common.Helper.Builders.Domain;
 using VideoApi.Domain;
 using VideoApi.Domain.Enums;
 
@@ -9,7 +10,8 @@ public class UpdateStatusTests
     [Test]
     public void should_update_status()
     {
-        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous");
+        var conference = new ConferenceBuilder().Build();
+        var telephoneParticipant = new TelephoneParticipant(Guid.NewGuid(), "Anonymous", conference);
         var status = TelephoneState.Disconnected;
         telephoneParticipant.UpdateStatus(status);
         telephoneParticipant.State.Should().Be(status);

--- a/VideoApi/VideoApi.UnitTests/Mappings/ConferenceToDetailsResponseMapperTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Mappings/ConferenceToDetailsResponseMapperTests.cs
@@ -4,6 +4,7 @@ using Testing.Common.Helper.Builders.Domain;
 using VideoApi.Common.Security.Supplier.Kinly;
 using VideoApi.Domain.Enums;
 using VideoApi.Mappings;
+using AudioPlaybackLanguage = VideoApi.Contract.Enums.AudioPlaybackLanguage;
 using RoomType = VideoApi.Contract.Enums.RoomType;
 
 namespace VideoApi.UnitTests.Mappings
@@ -51,6 +52,7 @@ namespace VideoApi.UnitTests.Mappings
                 .Excluding(x => x.CaseType)
                 .Excluding(x => x.HearingVenueName)
                 .Excluding(x => x.Supplier)
+                .Excluding(x=> x.AudioPlaybackLanguage)
             );
             
             response.TelephoneConferenceId.Should().Be(conference.MeetingRoom.TelephoneConferenceId);
@@ -59,6 +61,7 @@ namespace VideoApi.UnitTests.Mappings
             response.ClosedDateTime.Should().HaveValue().And.Be(conference.ClosedDateTime);
             response.CurrentStatus.Should().Be((Contract.Enums.ConferenceState)conference.GetCurrentStatus());
             response.Supplier.Should().Be((Contract.Enums.Supplier)conference.Supplier);
+            response.AudioPlaybackLanguage.Should().Be((AudioPlaybackLanguage)conference.AudioPlaybackLanguage);
             
             var participants = conference.GetParticipants();
             response.Participants.Should().BeEquivalentTo(participants, options => options

--- a/VideoApi/VideoApi.UnitTests/Services/BookingServiceTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Services/BookingServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Moq;
+using VideoApi.Contract.Enums;
 using VideoApi.Contract.Responses;
 using VideoApi.DAL.Commands;
 using VideoApi.DAL.Queries;
@@ -41,14 +42,14 @@ public class BookingServiceTests : ConferenceControllerTestBase
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock
             .Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).Throws(new DoubleBookingException(Guid.NewGuid()));
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).Throws(new DoubleBookingException(Guid.NewGuid()));
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
         
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         VideoPlatformServiceMock.Verify(v => v.GetVirtualCourtRoomAsync(It.IsAny<Guid>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Never);
     }
@@ -60,14 +61,16 @@ public class BookingServiceTests : ConferenceControllerTestBase
             { IngestUrl = "http://myIngestUrl.com" };
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock.Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(),
-            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync(MeetingRoom);
+            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(),
+            It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync(MeetingRoom);
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
-        
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
+
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(),
+                It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Once);
     }
     
@@ -78,14 +81,16 @@ public class BookingServiceTests : ConferenceControllerTestBase
             { IngestUrl = "http://myIngestUrl.com" };
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock.Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), false,
-            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync(MeetingRoom);
+            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(),
+            It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync(MeetingRoom);
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), false, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
-        
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
+
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), false, audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(),
+                It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Once);
     }
     
@@ -97,14 +102,14 @@ public class BookingServiceTests : ConferenceControllerTestBase
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock
             .Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync((MeetingRoom)null);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync((MeetingRoom)null);
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
         
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Never);
     }
     
@@ -115,14 +120,15 @@ public class BookingServiceTests : ConferenceControllerTestBase
             { IngestUrl = "http://myIngestUrl.com" };
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock.Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), true,
-            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync(MeetingRoom);
+            audioPlatformServiceResponse.IngestUrl, It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(),
+            It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync(MeetingRoom);
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
         
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), true, audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Once);
     }
     
@@ -133,16 +139,16 @@ public class BookingServiceTests : ConferenceControllerTestBase
             { IngestUrl = "http://myIngestUrl.com" };
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock.Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(),
-            It.IsAny<string>(), It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync(MeetingRoom);
+            It.IsAny<string>(), It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync(MeetingRoom);
         
         var response = await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
         
         response.Should().BeTrue();
         
         VideoPlatformServiceMock.Verify(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(),
             audioPlatformServiceResponse.IngestUrl,
-            It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+            It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Once);
     }
     
@@ -162,14 +168,14 @@ public class BookingServiceTests : ConferenceControllerTestBase
         SetupCallToMockRetryService(audioPlatformServiceResponse);
         VideoPlatformServiceMock
             .Setup(v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>())).ReturnsAsync((MeetingRoom)null);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>())).ReturnsAsync((MeetingRoom)null);
         
         await _service.BookMeetingRoomAsync(Guid.NewGuid(), true, audioPlatformServiceResponse.IngestUrl,
-            [], It.IsAny<ConferenceRoomType>());
+            [], It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
         
         VideoPlatformServiceMock.Verify(
             v => v.BookVirtualCourtroomAsync(It.IsAny<Guid>(), It.IsAny<bool>(), audioPlatformServiceResponse.IngestUrl,
-                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()), Times.Once);
+                It.IsAny<IEnumerable<EndpointDto>>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()), Times.Once);
         CommandHandlerMock.Verify(c => c.Handle(It.IsAny<UpdateMeetingRoomCommand>()), Times.Never);
         QueryHandlerMock.Verify(
             x => x.Handle<GetConferencesByTelephoneIdQuery, List<Conference>>(

--- a/VideoApi/VideoApi.UnitTests/Services/SupplierPlatformServiceTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Services/SupplierPlatformServiceTests.cs
@@ -20,7 +20,8 @@ using Task = System.Threading.Tasks.Task;
 using TestScore = VideoApi.Domain.Enums.TestScore;
 using UserRole = VideoApi.Domain.Enums.UserRole;
 using Supplier = VideoApi.Domain.Enums.Supplier;
-using ConferenceRoomType = VideoApi.Contract.Enums.ConferenceRoomType;
+using ConferenceRoomType = VideoApi.Domain.Enums.ConferenceRoomType;
+using AudioPlaybackLanguage = VideoApi.Domain.Enums.AudioPlaybackLanguage;
 
 namespace VideoApi.UnitTests.Services
 {
@@ -78,7 +79,7 @@ namespace VideoApi.UnitTests.Services
                 .ThrowsAsync(new SupplierApiException("", StatusCodes.Status409Conflict, "", null, It.IsAny<Exception>()));
 
             Assert.ThrowsAsync<DoubleBookingException>(() =>
-                    _SupplierPlatformService.BookVirtualCourtroomAsync(_testConference.Id, false, "", new List<EndpointDto>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()))
+                    _SupplierPlatformService.BookVirtualCourtroomAsync(_testConference.Id, false, "", new List<EndpointDto>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()))
                 .ErrorMessage.Should().Be($"Meeting room for conference {_testConference.Id} has already been booked");
         }
         
@@ -90,7 +91,7 @@ namespace VideoApi.UnitTests.Services
                 .ThrowsAsync(new SupplierApiException("", StatusCodes.Status500InternalServerError, "", null, It.IsAny<Exception>()));
 
             Assert.ThrowsAsync<SupplierApiException>(() =>
-                _SupplierPlatformService.BookVirtualCourtroomAsync(_testConference.Id, false, "", new List<EndpointDto>(), It.IsAny<string>(), It.IsAny<ConferenceRoomType>()));
+                _SupplierPlatformService.BookVirtualCourtroomAsync(_testConference.Id, false, "", new List<EndpointDto>(), It.IsAny<string>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>()));
         }
         
         [Test]
@@ -101,7 +102,9 @@ namespace VideoApi.UnitTests.Services
             const string conferenceRoleAsString = "Guest";
             var conferenceRole = (ConferenceRole)Enum.Parse(typeof(ConferenceRole), conferenceRoleAsString);
             const string conferenceRoomTypeAsString = "VA";
+            const string audioPlaybackLanguage = "English";
             var conferenceRoomType = (ConferenceRoomType)Enum.Parse(typeof(ConferenceRoomType), conferenceRoomTypeAsString);
+            var playbackLanguage = (AudioPlaybackLanguage)Enum.Parse(typeof(AudioPlaybackLanguage), audioPlaybackLanguage);
             var endpoints = new List<EndpointDto>
             {
                 new () {Id = Guid.NewGuid(), Pin = "1234", DisplayName = "one", SipAddress = "99191919", ConferenceRole = conferenceRole },
@@ -117,7 +120,8 @@ namespace VideoApi.UnitTests.Services
                 Streaming_enabled = false,
                 Streaming_url = null,
                 Jvs_endpoint = endpoints.Select(EndpointMapper.MapToEndpoint).ToList(),
-                RoomType = conferenceRoomTypeAsString
+                RoomType = conferenceRoomTypeAsString,
+                AudioPlaybackLanguage = audioPlaybackLanguage
             };
 
             var uris = new Uris
@@ -145,7 +149,7 @@ namespace VideoApi.UnitTests.Services
             var result = await _SupplierPlatformService.BookVirtualCourtroomAsync(_testConference.Id,
                 audioRecordingRequired,
                 ingestUrl,
-                endpoints, It.IsAny<string>(), conferenceRoomType);
+                endpoints, It.IsAny<string>(), conferenceRoomType, playbackLanguage);
 
             result.Should().NotBeNull();
             result.AdminUri.Should().Be(uris.Admin);
@@ -172,7 +176,7 @@ namespace VideoApi.UnitTests.Services
             _supplierApiClientMock.Setup(x => x.UpdateHearingAsync(It.IsAny<string>(), It.IsAny<UpdateHearingParams>()));
 
             var conferenceId = Guid.NewGuid();
-            await _SupplierPlatformService.UpdateVirtualCourtRoomAsync(conferenceId, true, new List<EndpointDto>());
+            await _SupplierPlatformService.UpdateVirtualCourtRoomAsync(conferenceId, true, new List<EndpointDto>(), It.IsAny<VideoApi.Domain.Enums.ConferenceRoomType>(), It.IsAny<VideoApi.Domain.Enums.AudioPlaybackLanguage>());
             
             _supplierApiClientMock.Verify(x => x.UpdateHearingAsync(conferenceId.ToString(), It.Is<UpdateHearingParams>(p => p.Recording_enabled)), Times.Once);
         }

--- a/VideoApi/VideoApi.UnitTests/packages.lock.json
+++ b/VideoApi/VideoApi.UnitTests/packages.lock.json
@@ -352,6 +352,15 @@
           "Microsoft.AspNetCore.Authorization": "2.2.0"
         }
       },
+      "Microsoft.AspNetCore.Connections.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.1.10",
+          "System.IO.Pipelines": "4.7.3"
+        }
+      },
       "Microsoft.AspNetCore.Hosting": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -412,6 +421,14 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
+      "Microsoft.AspNetCore.Http.Connections.Common": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
+        }
+      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -425,20 +442,11 @@
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
+        "resolved": "3.1.10",
+        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "3.1.10",
           "System.IO.Pipelines": "4.7.3"
-        }
-      },
-      "Microsoft.AspNetCore.JsonPatch": {
-        "type": "Transitive",
-        "resolved": "8.0.4",
-        "contentHash": "8iy7uza6GTuE5GadOryGfsGuA8xP1RTs16zqdXF5gM0b8iDfyNWnyDmatY5cZhXE1kJiko0S7s1T/gNFdIZ7Zg==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -695,6 +703,15 @@
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "System.Text.Json": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.KeyPerFile": {
+        "type": "Transitive",
+        "resolved": "3.1.11",
+        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.11",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
@@ -1616,6 +1633,11 @@
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "4.7.3",
+        "contentHash": "zykThu9scJyg2Yeg27GMZCbjzniIsmjtNP5x6kQCd/8rEeKXRy20fP2NOMS7xQ+0pS/E85LZQA+K1aoQLxiUdw=="
+      },
       "System.Linq": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2190,6 +2212,18 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "VH.Core.Configuration": {
+        "type": "Transitive",
+        "resolved": "0.1.13",
+        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
+          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
+          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
+          "Microsoft.Extensions.DependencyModel": "3.1.6",
+          "SonarAnalyzer.CSharp": "8.2.0.14119"
+        }
+      },
       "YamlDotNet": {
         "type": "Transitive",
         "resolved": "13.7.1",
@@ -2266,6 +2300,7 @@
           "NSwag.AspNetCore": "[14.0.7, )",
           "Scrutor": "[4.2.2, )",
           "System.Text.Json": "[8.0.4, )",
+          "VH.Core.Configuration": "[0.1.13, )",
           "VideoApi.Common": "[1.0.0, )",
           "VideoApi.Contract": "[1.0.0, )",
           "VideoApi.DAL": "[1.0.0, )",
@@ -2281,6 +2316,7 @@
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Identity.Client": "[4.60.3, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.1, )",
           "System.Text.Json": "[8.0.4, )",
           "VideoApi.Domain": "[1.0.0, )"

--- a/VideoApi/VideoApi.UnitTests/packages.lock.json
+++ b/VideoApi/VideoApi.UnitTests/packages.lock.json
@@ -352,15 +352,6 @@
           "Microsoft.AspNetCore.Authorization": "2.2.0"
         }
       },
-      "Microsoft.AspNetCore.Connections.Abstractions": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
-        }
-      },
       "Microsoft.AspNetCore.Hosting": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -421,14 +412,6 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections.Common": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
         "resolved": "2.2.0",
@@ -442,11 +425,10 @@
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
+        "resolved": "2.2.0",
+        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
+          "Microsoft.Extensions.Primitives": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -703,15 +685,6 @@
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "System.Text.Json": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Configuration.KeyPerFile": {
-        "type": "Transitive",
-        "resolved": "3.1.11",
-        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.11",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
@@ -1633,11 +1606,6 @@
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
       },
-      "System.IO.Pipelines": {
-        "type": "Transitive",
-        "resolved": "4.7.3",
-        "contentHash": "zykThu9scJyg2Yeg27GMZCbjzniIsmjtNP5x6kQCd/8rEeKXRy20fP2NOMS7xQ+0pS/E85LZQA+K1aoQLxiUdw=="
-      },
       "System.Linq": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2212,18 +2180,6 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
-      "VH.Core.Configuration": {
-        "type": "Transitive",
-        "resolved": "0.1.13",
-        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
-          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
-          "Microsoft.Extensions.DependencyModel": "3.1.6",
-          "SonarAnalyzer.CSharp": "8.2.0.14119"
-        }
-      },
       "YamlDotNet": {
         "type": "Transitive",
         "resolved": "13.7.1",
@@ -2300,7 +2256,6 @@
           "NSwag.AspNetCore": "[14.0.7, )",
           "Scrutor": "[4.2.2, )",
           "System.Text.Json": "[8.0.4, )",
-          "VH.Core.Configuration": "[0.1.13, )",
           "VideoApi.Common": "[1.0.0, )",
           "VideoApi.Contract": "[1.0.0, )",
           "VideoApi.DAL": "[1.0.0, )",

--- a/VideoApi/VideoApi/Controllers/EndpointsController.cs
+++ b/VideoApi/VideoApi/Controllers/EndpointsController.cs
@@ -82,7 +82,7 @@ namespace VideoApi.Controllers
             var endpointDtos = conference.GetEndpoints().Select(EndpointMapper.MapToEndpoint);
             var videoPlatformService = _supplierPlatformServiceFactory.Create(conference.Supplier);
             await videoPlatformService.UpdateVirtualCourtRoomAsync(conference.Id, conference.AudioRecordingRequired,
-                endpointDtos);
+                endpointDtos, conference.ConferenceRoomType, conference.AudioPlaybackLanguage);
             
             _logger.LogDebug("Successfully added endpoint {DisplayName} to conference", request.DisplayName);
             return NoContent();
@@ -99,7 +99,7 @@ namespace VideoApi.Controllers
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         public async Task<IActionResult> RemoveEndpointFromConference(Guid conferenceId, string sipAddress)
         {
-            _logger.LogDebug("Attempting to remove endpoint {sipAddress} from conference", sipAddress);
+            _logger.LogDebug("Attempting to remove endpoint {SipAddress} from conference", sipAddress);
             
             var command = new RemoveEndpointCommand(conferenceId, sipAddress);
             await _commandHandler.Handle(command);
@@ -110,9 +110,9 @@ namespace VideoApi.Controllers
             var endpointDtos = conference.GetEndpoints().Select(EndpointMapper.MapToEndpoint);
             var videoPlatformService = _supplierPlatformServiceFactory.Create(conference.Supplier);
             await videoPlatformService.UpdateVirtualCourtRoomAsync(conference.Id, conference.AudioRecordingRequired,
-                endpointDtos);
+                endpointDtos, conference.ConferenceRoomType, conference.AudioPlaybackLanguage);
             
-            _logger.LogDebug("Successfully removed endpoint {sipAddress} from conference", sipAddress);
+            _logger.LogDebug("Successfully removed endpoint {SipAddress} from conference", sipAddress);
             return NoContent();
         }
         
@@ -130,12 +130,13 @@ namespace VideoApi.Controllers
             [FromBody] UpdateEndpointRequest request)
         {
             _logger.LogDebug(
-                "Attempting to update endpoint {sipAddress} with display name {DisplayName}", sipAddress,
+                "Attempting to update endpoint {SipAddress} with display name {DisplayName}", sipAddress,
                 request.DisplayName);
             
             var command =
                 new UpdateEndpointCommand(conferenceId, sipAddress, request.DisplayName, request.DefenceAdvocate, 
                     (Domain.Enums.ConferenceRole)request.ConferenceRole);
+            // update the conference with the new role and new theme language
             await _commandHandler.Handle(command);
             
             if (!string.IsNullOrWhiteSpace(request.DisplayName))
@@ -144,7 +145,7 @@ namespace VideoApi.Controllers
             }
             
             _logger.LogDebug(
-                "Successfully updated endpoint {sipAddress} with display name {DisplayName}", sipAddress,
+                "Successfully updated endpoint {SipAddress} with display name {DisplayName}", sipAddress,
                 request.DisplayName);
             return Ok();
         }
@@ -156,8 +157,10 @@ namespace VideoApi.Controllers
                     new GetConferenceByIdQuery(conferenceId));
             var endpointDtos = conference.GetEndpoints().Select(EndpointMapper.MapToEndpoint);
             var videoPlatformService = _supplierPlatformServiceFactory.Create(conference.Supplier);
+
             await videoPlatformService.UpdateVirtualCourtRoomAsync(conference.Id, conference.AudioRecordingRequired,
-                endpointDtos);
+                endpointDtos, conference.ConferenceRoomType,
+                conference.AudioPlaybackLanguage);
         }
     }
 }

--- a/VideoApi/VideoApi/Extensions/ContractExtensions.cs
+++ b/VideoApi/VideoApi/Extensions/ContractExtensions.cs
@@ -55,6 +55,21 @@ namespace VideoApi.Extensions
             return Enum.Parse<Domain.Enums.EventType>(eventType.ToString());
         }
         
+        public static Domain.Enums.ConferenceRoomType MapToDomainEnum(this Contract.Enums.ConferenceRoomType roomType)
+        {
+            return Enum.Parse<Domain.Enums.ConferenceRoomType>(roomType.ToString());
+        }
+        
+        public static Domain.Enums.AudioPlaybackLanguage MapToDomainEnum(this Contract.Enums.AudioPlaybackLanguage audioRecordingStatus)
+        {
+            return Enum.Parse<Domain.Enums.AudioPlaybackLanguage>(audioRecordingStatus.ToString());
+        }
+        
+        public static Domain.Enums.Supplier MapToDomainEnum(this Contract.Enums.Supplier supplier)
+        {
+            return Enum.Parse<Domain.Enums.Supplier>(supplier.ToString());
+        }
+        
         public static Domain.Enums.VirtualCourtRoomType MapToDomainEnum(this Contract.Enums.VirtualCourtRoomType roomType)
         {
             return Enum.Parse<Domain.Enums.VirtualCourtRoomType>(roomType.ToString());

--- a/VideoApi/VideoApi/Mappings/ConferenceCoreResponseMapper.cs
+++ b/VideoApi/VideoApi/Mappings/ConferenceCoreResponseMapper.cs
@@ -22,6 +22,7 @@ public static class ConferenceCoreResponseMapper
         response.Participants = MapParticipants(conference.Participants);
         response.CaseName = conference.CaseName;
         response.ConferenceRoomType = (Contract.Enums.ConferenceRoomType)conference.ConferenceRoomType;
+        response.AudioPlaybackLanguage = (Contract.Enums.AudioPlaybackLanguage)conference.AudioPlaybackLanguage;
         return response;
     }
     

--- a/VideoApi/VideoApi/Mappings/ConferenceToDetailsResponseMapper.cs
+++ b/VideoApi/VideoApi/Mappings/ConferenceToDetailsResponseMapper.cs
@@ -37,6 +37,7 @@ namespace VideoApi.Mappings
             response.CaseName = conference.CaseName;
             response.Supplier = (Contract.Enums.Supplier)conference.Supplier;
             response.ConferenceRoomType = (Contract.Enums.ConferenceRoomType)conference.ConferenceRoomType;
+            response.AudioPlaybackLanguage = (Contract.Enums.AudioPlaybackLanguage)conference.AudioPlaybackLanguage;
             
             if (response.MeetingRoom != null)
                 response.MeetingRoom.PexipSelfTestNode = pexipSelfTestNode;

--- a/VideoApi/VideoApi/Services/BookingService.cs
+++ b/VideoApi/VideoApi/Services/BookingService.cs
@@ -44,7 +44,7 @@ public class BookingService(
     {
         MeetingRoom meetingRoom;
         var telephoneId = await CreateUniqueTelephoneId();
-        var videoPlatformService = _supplierPlatformServiceFactory.Create((Domain.Enums.Supplier)supplier);
+        var videoPlatformService = _supplierPlatformServiceFactory.Create(supplier);
         var endpointDtos = endpoints.ToList();
         try
         {
@@ -95,12 +95,12 @@ public class BookingService(
         
         var endpoints = request.Endpoints
             .Select(x => new Endpoint(x.DisplayName, x.SipAddress, x.Pin, x.DefenceAdvocate, 
-                (Domain.Enums.ConferenceRole)x.ConferenceRole))
+                (ConferenceRole)x.ConferenceRole))
             .ToList();
         
         var linkedParticipants = request.Participants
             .SelectMany(x => x.LinkedParticipants)
-            .Select(x => new LinkedParticipantDto()
+            .Select(x => new LinkedParticipantDto
             {
                 ParticipantRefId = x.ParticipantRefId,
                 LinkedRefId = x.LinkedRefId,
@@ -112,9 +112,9 @@ public class BookingService(
             request.HearingRefId, request.CaseType, request.ScheduledDateTime, request.CaseNumber,
             request.CaseName, request.ScheduledDuration, participants, request.HearingVenueName,
             request.AudioRecordingRequired, ingestUrl, endpoints, linkedParticipants,
-            (Domain.Enums.Supplier)request.Supplier,
-            (Domain.Enums.ConferenceRoomType)request.ConferenceRoomType,
-            (Domain.Enums.AudioPlaybackLanguage)request.AudioPlaybackLanguage
+            (Supplier)request.Supplier,
+            (ConferenceRoomType)request.ConferenceRoomType,
+            (AudioPlaybackLanguage)request.AudioPlaybackLanguage
         );
         
         await _commandHandler.Handle(createConferenceCommand);

--- a/VideoApi/VideoApi/VideoApi.csproj
+++ b/VideoApi/VideoApi/VideoApi.csproj
@@ -45,7 +45,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
-    <PackageReference Include="VH.Core.Configuration" Version="0.1.13" />
     <PackageReference Include="ZymLabs.NSwag.FluentValidation" Version="0.6.3" />
   </ItemGroup>
 

--- a/VideoApi/VideoApi/packages.lock.json
+++ b/VideoApi/VideoApi/packages.lock.json
@@ -164,19 +164,6 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "VH.Core.Configuration": {
-        "type": "Direct",
-        "requested": "[0.1.13, )",
-        "resolved": "0.1.13",
-        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
-          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
-          "Microsoft.Extensions.DependencyModel": "3.1.6",
-          "SonarAnalyzer.CSharp": "8.2.0.14119"
-        }
-      },
       "ZymLabs.NSwag.FluentValidation": {
         "type": "Direct",
         "requested": "[0.6.3, )",
@@ -353,53 +340,6 @@
           "System.IO.FileSystem.AccessControl": "4.7.0"
         }
       },
-      "Microsoft.AspNetCore.Authentication.Abstractions": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Authentication.Core": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Authorization": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Authorization.Policy": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Authorization": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Connections.Abstractions": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
-        }
-      },
       "Microsoft.AspNetCore.Hosting": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -422,33 +362,33 @@
       },
       "Microsoft.AspNetCore.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
+        "resolved": "2.1.1",
+        "contentHash": "76cKcp2pWhvdV2TXTqMg/DyW7N6cDzTEhtL8vVWFShQN+Ylwv3eO/vUQr2BS3Hz4IZHEpL+FOo2T+MtymHDqDQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "2.2.0"
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.1.1",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "2.1.1"
         }
       },
       "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
+        "resolved": "2.1.1",
+        "contentHash": "+vD7HJYzAXNq17t+NgRkpS38cxuAyOBu8ixruOiA3nWsybozolUdALWiZ5QFtGRzajSLPFA2YsbO3NPcqoUwcw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.AspNetCore.Http.Features": "2.1.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "2.1.1"
         }
       },
       "Microsoft.AspNetCore.Http": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "YogBSMotWPAS/X5967pZ+yyWPQkThxhmzAwyCHCSSldzYBkW5W5d6oPfBaPqQOnSHYTpSOSOkpZoAce0vwb6+A==",
+        "resolved": "2.1.22",
+        "contentHash": "+Blk++1JWqghbl8+3azQmKhiNZA5wAepL9dY2I6KVmu2Ri07MAcvAVC888qUvO7yd7xgRgZOMfihezKg14O/2A==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.WebUtilities": "2.2.0",
-          "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0",
-          "Microsoft.Net.Http.Headers": "2.2.0"
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.AspNetCore.WebUtilities": "2.1.1",
+          "Microsoft.Extensions.ObjectPool": "2.1.1",
+          "Microsoft.Extensions.Options": "2.1.1",
+          "Microsoft.Net.Http.Headers": "2.1.1"
         }
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
@@ -460,32 +400,23 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections.Common": {
-        "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
+        "resolved": "2.1.1",
+        "contentHash": "ncAgV+cqsWSqjLXFUTyObGh4Tr7ShYYs3uW8Q/YpRwZn7eLV7dux5Z6GLY+rsdzmIHiia3Q2NWbLULQi7aziHw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Net.Http.Headers": "2.2.0",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "2.1.1",
+          "Microsoft.Net.Http.Headers": "2.1.1",
           "System.Buffers": "4.5.0"
         }
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "3.1.10",
-        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
+        "resolved": "2.2.0",
+        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.10",
-          "System.IO.Pipelines": "4.7.3"
+          "Microsoft.Extensions.Primitives": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -495,48 +426,6 @@
         "dependencies": {
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Mvc.Core": {
-        "type": "Transitive",
-        "resolved": "2.2.5",
-        "contentHash": "/8sr8ixIUD57UFwUntha9bOwex7/AkZfdk1f9oNJG1Ek7p/uuKVa7fuHmYZpQOf35Oxrt+2Ku4WPwMSbNxOuWg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "2.2.0",
-          "Microsoft.Extensions.DependencyModel": "2.1.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "System.Diagnostics.DiagnosticSource": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.ResponseCaching.Abstractions": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "2.2.0"
-        }
-      },
-      "Microsoft.AspNetCore.Routing": {
-        "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "jAhDBy0wryOnMhhZTtT9z63gJbvCzFuLm8yC6pHzuVu9ZD1dzg0ltxIwT4cfwuNkIL/TixdKsm3vpVOpG8euWQ==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
-          "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions": {
@@ -549,10 +438,10 @@
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "9ErxAAKaDzxXASB/b5uLEkLgUWv1QbeVxyJYEHQwMaxXOeFFVkQxiq8RyfVcifLU7NR0QY0p3acqx4ZpYfhHDg==",
+        "resolved": "2.1.1",
+        "contentHash": "PGKIZt4+412Z/XPoSjvYu/QIbTxcAQuEFNoA1Pw8a9mgmO0ZhNBmfaNyhgXFf7Rq62kP0tT/2WXpxdcQhkFUPA==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "2.2.0",
+          "Microsoft.Net.Http.Headers": "2.1.1",
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
@@ -780,15 +669,6 @@
           "System.Text.Json": "8.0.0"
         }
       },
-      "Microsoft.Extensions.Configuration.KeyPerFile": {
-        "type": "Transitive",
-        "resolved": "3.1.11",
-        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.11",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
-        }
-      },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -894,8 +774,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "gA8H7uQOnM5gb+L0uTNjViHYr+hRDqCdfugheGo/MxQnuHzmhhzCBTIPm19qL1z1Xe0NEMabfcOBGv9QghlZ8g=="
+        "resolved": "2.1.1",
+        "contentHash": "SErON45qh4ogDp6lr6UvVmFYW0FERihW+IQ+2JyFv1PUyWktcJytFaWH5zarufJvZwhci7Rf1IyGXr9pVEadTw=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",

--- a/VideoApi/VideoApi/packages.lock.json
+++ b/VideoApi/VideoApi/packages.lock.json
@@ -164,6 +164,19 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
+      "VH.Core.Configuration": {
+        "type": "Direct",
+        "requested": "[0.1.13, )",
+        "resolved": "0.1.13",
+        "contentHash": "fEtq8dy7GbJ8eUDc5kmwg3Ze+6C7JEPSHlmvz22W8UPX/x7ujBTr5MqUdpKNQganaHalt/6DHfHi+gxlPSUjiw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections.Common": "3.1.10",
+          "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
+          "Microsoft.Extensions.Configuration.KeyPerFile": "3.1.11",
+          "Microsoft.Extensions.DependencyModel": "3.1.6",
+          "SonarAnalyzer.CSharp": "8.2.0.14119"
+        }
+      },
       "ZymLabs.NSwag.FluentValidation": {
         "type": "Direct",
         "requested": "[0.6.3, )",
@@ -340,6 +353,53 @@
           "System.IO.FileSystem.AccessControl": "4.7.0"
         }
       },
+      "Microsoft.AspNetCore.Authentication.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Options": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Core": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Options": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization.Policy": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authorization": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Connections.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "+bggAAN8KS7tE5QfK1ZXJSukL+LRUX1t/DrN2iRT3CD3lErUsyww9hHyIaIX+YK1A8UpmqjVukFxgc5w7lvlKg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.1.10",
+          "System.IO.Pipelines": "4.7.3"
+        }
+      },
       "Microsoft.AspNetCore.Hosting": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -362,33 +422,33 @@
       },
       "Microsoft.AspNetCore.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "76cKcp2pWhvdV2TXTqMg/DyW7N6cDzTEhtL8vVWFShQN+Ylwv3eO/vUQr2BS3Hz4IZHEpL+FOo2T+MtymHDqDQ==",
+        "resolved": "2.2.0",
+        "contentHash": "ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.1.1",
-          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
-          "Microsoft.Extensions.Hosting.Abstractions": "2.1.1"
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "+vD7HJYzAXNq17t+NgRkpS38cxuAyOBu8ixruOiA3nWsybozolUdALWiZ5QFtGRzajSLPFA2YsbO3NPcqoUwcw==",
+        "resolved": "2.2.0",
+        "contentHash": "1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "2.1.1",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.1.1"
+          "Microsoft.AspNetCore.Http.Features": "2.2.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Http": {
         "type": "Transitive",
-        "resolved": "2.1.22",
-        "contentHash": "+Blk++1JWqghbl8+3azQmKhiNZA5wAepL9dY2I6KVmu2Ri07MAcvAVC888qUvO7yd7xgRgZOMfihezKg14O/2A==",
+        "resolved": "2.2.0",
+        "contentHash": "YogBSMotWPAS/X5967pZ+yyWPQkThxhmzAwyCHCSSldzYBkW5W5d6oPfBaPqQOnSHYTpSOSOkpZoAce0vwb6+A==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
-          "Microsoft.AspNetCore.WebUtilities": "2.1.1",
-          "Microsoft.Extensions.ObjectPool": "2.1.1",
-          "Microsoft.Extensions.Options": "2.1.1",
-          "Microsoft.Net.Http.Headers": "2.1.1"
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.WebUtilities": "2.2.0",
+          "Microsoft.Extensions.ObjectPool": "2.2.0",
+          "Microsoft.Extensions.Options": "2.2.0",
+          "Microsoft.Net.Http.Headers": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
@@ -400,33 +460,32 @@
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
+      "Microsoft.AspNetCore.Http.Connections.Common": {
+        "type": "Transitive",
+        "resolved": "3.1.10",
+        "contentHash": "D/nIhfWpIqNZTD+5g6q4RXO5OvFdcmLByY9RnrDV+40DHmJ+NPd4n/wC/EbUvv8WL8d7MZqT4kux1bK/I9ETyQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.1.10"
+        }
+      },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "ncAgV+cqsWSqjLXFUTyObGh4Tr7ShYYs3uW8Q/YpRwZn7eLV7dux5Z6GLY+rsdzmIHiia3Q2NWbLULQi7aziHw==",
+        "resolved": "2.2.0",
+        "contentHash": "2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.1.1",
-          "Microsoft.Net.Http.Headers": "2.1.1",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
+          "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Buffers": "4.5.0"
         }
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "ziFz5zH8f33En4dX81LW84I6XrYXKf9jg6aM39cM+LffN9KJahViKZ61dGMSO2gd3e+qe5yBRwsesvyqlZaSMg==",
+        "resolved": "3.1.10",
+        "contentHash": "/uQT0Wx1QMkrefYCuyPzJw0/CZbC++yUBLqGj1WDL7paqC7OqXxfQVT6o9xU0ni+d9SP2Y76UIaYUayvEMNm1w==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "3.1.10",
           "System.IO.Pipelines": "4.7.3"
-        }
-      },
-      "Microsoft.AspNetCore.JsonPatch": {
-        "type": "Transitive",
-        "resolved": "8.0.4",
-        "contentHash": "8iy7uza6GTuE5GadOryGfsGuA8xP1RTs16zqdXF5gM0b8iDfyNWnyDmatY5cZhXE1kJiko0S7s1T/gNFdIZ7Zg==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
@@ -436,6 +495,48 @@
         "dependencies": {
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Core": {
+        "type": "Transitive",
+        "resolved": "2.2.5",
+        "contentHash": "/8sr8ixIUD57UFwUntha9bOwex7/AkZfdk1f9oNJG1Ek7p/uuKVa7fuHmYZpQOf35Oxrt+2Ku4WPwMSbNxOuWg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Routing": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.Extensions.DependencyInjection": "2.2.0",
+          "Microsoft.Extensions.DependencyModel": "2.1.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
+          "System.Diagnostics.DiagnosticSource": "4.5.0",
+          "System.Threading.Tasks.Extensions": "4.5.1"
+        }
+      },
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.2.0"
+        }
+      },
+      "Microsoft.AspNetCore.Routing": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "jAhDBy0wryOnMhhZTtT9z63gJbvCzFuLm8yC6pHzuVu9ZD1dzg0ltxIwT4cfwuNkIL/TixdKsm3vpVOpG8euWQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
+          "Microsoft.Extensions.ObjectPool": "2.2.0",
+          "Microsoft.Extensions.Options": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions": {
@@ -448,10 +549,10 @@
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "PGKIZt4+412Z/XPoSjvYu/QIbTxcAQuEFNoA1Pw8a9mgmO0ZhNBmfaNyhgXFf7Rq62kP0tT/2WXpxdcQhkFUPA==",
+        "resolved": "2.2.0",
+        "contentHash": "9ErxAAKaDzxXASB/b5uLEkLgUWv1QbeVxyJYEHQwMaxXOeFFVkQxiq8RyfVcifLU7NR0QY0p3acqx4ZpYfhHDg==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "2.1.1",
+          "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Text.Encodings.Web": "4.5.0"
         }
       },
@@ -679,6 +780,15 @@
           "System.Text.Json": "8.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration.KeyPerFile": {
+        "type": "Transitive",
+        "resolved": "3.1.11",
+        "contentHash": "u3Y7Hs22o7vtN3hVtiS9/FwhG1BI5Vc24wucLU1wUvWS4jY1Ddx9h6H1srVtdtXA04tZbGrYBUoCbZDHEyddzQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.11",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.11"
+        }
+      },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -784,8 +894,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "SErON45qh4ogDp6lr6UvVmFYW0FERihW+IQ+2JyFv1PUyWktcJytFaWH5zarufJvZwhci7Rf1IyGXr9pVEadTw=="
+        "resolved": "2.2.0",
+        "contentHash": "gA8H7uQOnM5gb+L0uTNjViHYr+hRDqCdfugheGo/MxQnuHzmhhzCBTIPm19qL1z1Xe0NEMabfcOBGv9QghlZ8g=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -1541,6 +1651,7 @@
           "Microsoft.ApplicationInsights.AspNetCore": "[2.22.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Identity.Client": "[4.60.3, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.5.1, )",
           "System.Text.Json": "[8.0.4, )",
           "VideoApi.Domain": "[1.0.0, )"


### PR DESCRIPTION
### Jira link

VIH-11042

### Change description

Push the room type and audio language to video supplier

This pull request introduces a new feature to support audio playback language settings for conferences, along with various related updates across the codebase. The most important changes include adding the `AudioPlaybackLanguage` enum, updating multiple classes to include this new property, and modifying the database schema to store this information.

### Feature Addition: Audio Playback Language

* [`VideoApi/VideoApi.Contract/Enums/AudioPlaybackLanguage.cs`](diffhunk://#diff-dd52787e1d68b3422599aabc1495a75a7705c68ffe55693991bea2591457c7c3R1-R8): Added a new enum `AudioPlaybackLanguage` with options for English, Welsh, and both languages.
* Default value EnglishAndWelsh
* Update the ctor for Conference.cs to require the `AudioLanguage`
* Added a migration to Add the AudioPlaybackLanguage column to Conference