### PR TITLE
VIH-11229 add verbose error messages in TransferEventHandler.cs

### DIFF
--- a/VideoApi/VideoApi.Events/Handlers/TransferEventHandler.cs
+++ b/VideoApi/VideoApi.Events/Handlers/TransferEventHandler.cs
@@ -54,7 +54,6 @@ namespace VideoApi.Events.Handlers
                 Logger.LogError(new RoomNotFoundException(SourceConference.Id, callbackEvent.TransferredFromRoomLabel),
                     "Unable to find room {RoomLabel} in conference {ConferenceId}",
                     callbackEvent.TransferredFromRoomLabel, SourceConference.Id);
-                Logger.LogError("Unable to find room {RoomLabel} in conference {ConferenceId}", callbackEvent.TransferredFromRoomLabel, SourceConference.Id);
             }
             else if (room.Status == RoomStatus.Live && room.RoomParticipants.Count == 0)
             {

--- a/VideoApi/VideoApi.Events/Handlers/TransferEventHandler.cs
+++ b/VideoApi/VideoApi.Events/Handlers/TransferEventHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using VideoApi.Common;
 using VideoApi.DAL.Commands;
 using VideoApi.DAL.Commands.Core;
+using VideoApi.DAL.Exceptions;
 using VideoApi.DAL.Queries;
 using VideoApi.DAL.Queries.Core;
 using VideoApi.Domain;
@@ -26,6 +27,7 @@ namespace VideoApi.Events.Handlers
         
         protected override async Task PublishStatusAsync(CallbackEvent callbackEvent)
         {
+            if(SourceParticipant == null) throw new ParticipantNotFoundException(callbackEvent.ParticipantId);
             BadRequestException.ThrowIfNull(callbackEvent.TransferredFromRoomLabel);
             BadRequestException.ThrowIfNull(callbackEvent.TransferredToRoomLabel);
             Logger.LogInformation("Transfer callback received - {ConferenceId} - {ParticipantId}/{ParticipantRoomId} - {FromRoom} {FromRoomLabel} - {ToRoom} {ToRoomLabel}",
@@ -49,6 +51,9 @@ namespace VideoApi.Events.Handlers
             var room = await QueryHandler.Handle<GetConsultationRoomByIdQuery, ConsultationRoom>(roomQuery);
             if (room == null)
             {
+                Logger.LogError(new RoomNotFoundException(SourceConference.Id, callbackEvent.TransferredFromRoomLabel),
+                    "Unable to find room {RoomLabel} in conference {ConferenceId}",
+                    callbackEvent.TransferredFromRoomLabel, SourceConference.Id);
                 Logger.LogError("Unable to find room {RoomLabel} in conference {ConferenceId}", callbackEvent.TransferredFromRoomLabel, SourceConference.Id);
             }
             else if (room.Status == RoomStatus.Live && room.RoomParticipants.Count == 0)


### PR DESCRIPTION
### Jira link

VIH-11229

### Change description

add verbose error messages in TransferEventHandler.cs

This will help the supplier understand why a callback event has failed (i.e. if an invalid id has been provided or missing property for a given event type)
