### PR TITLE
VIH-11291 Fix for audio reconciliation failures

### DIFF
--- a/VideoApi/VideoApi.DAL/Queries/GetConferenceHearingRoomsByDateQuery.cs
+++ b/VideoApi/VideoApi.DAL/Queries/GetConferenceHearingRoomsByDateQuery.cs
@@ -40,7 +40,7 @@ namespace VideoApi.DAL.Queries
                           {
                               HearingRefId = conference.HearingRefId,
                               Label = string.Empty,
-                              FileNamePrefix = "_" + query.DateStamp.Date.ToString("yyyy-MM-dd")
+                              FileNamePrefix = conference.IngestUrlFilenamePrefix + "_" + query.DateStamp.Date.ToString("yyyy-MM-dd")
                           };
 
             return await results.ToListAsync();

--- a/VideoApi/VideoApi.DAL/Queries/GetConferenceHearingRoomsByDateQuery.cs
+++ b/VideoApi/VideoApi.DAL/Queries/GetConferenceHearingRoomsByDateQuery.cs
@@ -40,7 +40,7 @@ namespace VideoApi.DAL.Queries
                           {
                               HearingRefId = conference.HearingRefId,
                               Label = string.Empty,
-                              FileNamePrefix = conference.IngestUrlFilenamePrefix + "_" + query.DateStamp.Date.ToString("yyyy-MM-dd")
+                              FileNamePrefix = conference.IngestUrlFilenamePrefix
                           };
 
             return await results.ToListAsync();

--- a/VideoApi/VideoApi.Domain/Conference.cs
+++ b/VideoApi/VideoApi.Domain/Conference.cs
@@ -68,7 +68,7 @@ namespace VideoApi.Domain
         public AudioPlaybackLanguage AudioPlaybackLanguage { get; private set; }
 
         /// <summary>
-        /// Extracts the filename prefix from the ingest url - the portion of the filename before the datetime stamp is appended
+        /// Extracts the filename prefix from the ingest url - the filename portion before the datetime stamp is appended
         /// by wowza
         /// </summary>
         public string IngestUrlFilenamePrefix

--- a/VideoApi/VideoApi.Domain/Conference.cs
+++ b/VideoApi/VideoApi.Domain/Conference.cs
@@ -66,7 +66,24 @@ namespace VideoApi.Domain
         public Supplier Supplier { get; private set; }
         public ConferenceRoomType ConferenceRoomType { get; private set; }
         public AudioPlaybackLanguage AudioPlaybackLanguage { get; private set; }
-        
+
+        /// <summary>
+        /// Extracts the filename prefix from the ingest url - the portion of the filename before the datetime stamp is appended
+        /// by wowza
+        /// </summary>
+        public string IngestUrlFilenamePrefix
+        {
+            get
+            {
+                if (IngestUrl == null) return null;
+                
+                var lastSlashIndex = IngestUrl.LastIndexOf('/');
+                var filenamePrefix = IngestUrl[(lastSlashIndex + 1)..];
+                
+                return filenamePrefix;
+            }
+        }
+
         public void UpdateMeetingRoom(string adminUri, string judgeUri, string participantUri, string pexipNode, string telephoneConferenceId)
         {
             telephoneConferenceId ??= MeetingRoom?.TelephoneConferenceId;

--- a/VideoApi/VideoApi.IntegrationTests/Database/Queries/GetConferenceHearingRoomsByDateQueryTests.cs
+++ b/VideoApi/VideoApi.IntegrationTests/Database/Queries/GetConferenceHearingRoomsByDateQueryTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
@@ -39,6 +38,9 @@ namespace VideoApi.IntegrationTests.Database.Queries
             var result = await _handler.Handle(query);
 
             result.Should().NotBeEmpty();
+            result[0].HearingRefId.Should().Be(conference.HearingRefId);
+            result[0].Label.Should().BeEmpty();
+            result[0].FileNamePrefix.Should().Be($"{conference.IngestUrlFilenamePrefix}_{DateTime.Today:yyyy-MM-dd}");
         }
 
         [TearDown]

--- a/VideoApi/VideoApi.IntegrationTests/Database/Queries/GetConferenceHearingRoomsByDateQueryTests.cs
+++ b/VideoApi/VideoApi.IntegrationTests/Database/Queries/GetConferenceHearingRoomsByDateQueryTests.cs
@@ -40,7 +40,7 @@ namespace VideoApi.IntegrationTests.Database.Queries
             result.Should().NotBeEmpty();
             result[0].HearingRefId.Should().Be(conference.HearingRefId);
             result[0].Label.Should().BeEmpty();
-            result[0].FileNamePrefix.Should().Be($"{conference.IngestUrlFilenamePrefix}_{DateTime.Today:yyyy-MM-dd}");
+            result[0].FileNamePrefix.Should().Be(conference.IngestUrlFilenamePrefix);
         }
 
         [TearDown]

--- a/VideoApi/VideoApi.IntegrationTests/VideoApi.IntegrationTests.csproj
+++ b/VideoApi/VideoApi.IntegrationTests/VideoApi.IntegrationTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/VideoApi/VideoApi.IntegrationTests/packages.lock.json
+++ b/VideoApi/VideoApi.IntegrationTests/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.3, )",
-        "resolved": "6.0.3",
-        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
       },
       "FluentAssertions": {
         "type": "Direct",

--- a/VideoApi/VideoApi.UnitTests/Domain/Conference/GetIngestUrlFilenamePrefixTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Domain/Conference/GetIngestUrlFilenamePrefixTests.cs
@@ -1,0 +1,49 @@
+using Testing.Common.Helper.Builders.Domain;
+
+namespace VideoApi.UnitTests.Domain.Conference;
+
+public class GetIngestUrlFilenamePrefixTests
+{
+    [Test]
+    public void Should_return_ingest_url_filename_prefix()
+    {
+        // Arrange
+        var conference = new ConferenceBuilder().Build();
+        conference.IngestUrl =
+            "rtmps://platform.net:443/vh-recording-app/ABA4-1040Test-c388a080-53d1-4899-98cc-569ba6213244";
+
+        // Act
+        var prefix = conference.IngestUrlFilenamePrefix;
+
+        // Assert
+        prefix.Should().Be("ABA4-1040Test-c388a080-53d1-4899-98cc-569ba6213244");
+    }
+
+    [Test]
+    public void Should_return_null_when_ingest_url_is_null()
+    {
+        // Arrange
+        var conference = new ConferenceBuilder().Build();
+        conference.IngestUrl = null;
+        
+        // Act
+        var prefix = conference.IngestUrlFilenamePrefix;
+        
+        // Assert
+        prefix.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_return_empty_string_when_ingest_url_is_empty_string()
+    {
+        // Arrange
+        var conference = new ConferenceBuilder().Build();
+        conference.IngestUrl = string.Empty;
+        
+        // Act
+        var prefix = conference.IngestUrlFilenamePrefix;
+        
+        // Assert
+        prefix.Should().Be(string.Empty);
+    }
+}

--- a/VideoApi/VideoApi.UnitTests/Mappings/ConferenceCoreResponseMapperTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Mappings/ConferenceCoreResponseMapperTests.cs
@@ -40,6 +40,7 @@ public class ConferenceCoreResponseMapperTests
             .Excluding(x => x.Supplier)
             .Excluding(x => x.AudioRecordingRequired)
             .Excluding(x => x.MeetingRoom)
+            .Excluding(x => x.IngestUrlFilenamePrefix)
         );
         
         response.StartedDateTime.Should().HaveValue().And.Be(conference.ActualStartTime);

--- a/VideoApi/VideoApi.UnitTests/Mappings/ConferenceToDetailsResponseMapperTests.cs
+++ b/VideoApi/VideoApi.UnitTests/Mappings/ConferenceToDetailsResponseMapperTests.cs
@@ -53,6 +53,7 @@ namespace VideoApi.UnitTests.Mappings
                 .Excluding(x => x.HearingVenueName)
                 .Excluding(x => x.Supplier)
                 .Excluding(x=> x.AudioPlaybackLanguage)
+                .Excluding(x => x.IngestUrlFilenamePrefix)
             );
             
             response.TelephoneConferenceId.Should().Be(conference.MeetingRoom.TelephoneConferenceId);

--- a/VideoApi/VideoApi.UnitTests/VideoApi.UnitTests.csproj
+++ b/VideoApi/VideoApi.UnitTests/VideoApi.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="7.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/VideoApi/VideoApi.UnitTests/packages.lock.json
+++ b/VideoApi/VideoApi.UnitTests/packages.lock.json
@@ -15,9 +15,9 @@
       },
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.3, )",
-        "resolved": "6.0.3",
-        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
       },
       "FluentAssertions": {
         "type": "Direct",


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11291

### Change description

- The filename prefix for audio recordings was changed a while ago from {hearing id} to {service id}-{case number}-{hearing id}. Update the api to return this new prefix, extracted from the ingest url. Strip out the datetime so that the scheduler job can group the recordings for a given hearing
- Update coverlet package - fixes issue with 0% code coverage reported